### PR TITLE
sns_linac_lattice_factory.py contained useless line setting up an unused parameter.

### DIFF
--- a/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
+++ b/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
@@ -152,7 +152,6 @@ class SNS_LinacLatticeFactory:
                 if node_type == "QUAD":
                     accNode = Quad(node_da.stringValue("name"))
                     accNode.setParam("dB/dr", params_da.doubleValue("field"))
-                    accNode.setParam("field", params_da.doubleValue("field"))
                     accNode.setLength(node_length)
                     if params_da.hasAttribute("poles"):
                         # accNode.setParam("poles",[int(x) for x in eval(params_da.stringValue("poles"))])


### PR DESCRIPTION
sns_linac_lattice_factory.py contained the following line (line 155) in the function getLinacAccLatticeFromDA when building quadrupoles:

accNode.setParam("field", params_da.doubleValue("field"))

This line is unnecessary as the key "dB/dr" is used in the Quadrupole functions getField and setField to get the needed field parameter. The key "field" is used nowhere.