### PR TITLE
Bugfix in the matching routine

### DIFF
--- a/py/orbit/matrix_lattice/MATRIX_Lattice.py
+++ b/py/orbit/matrix_lattice/MATRIX_Lattice.py
@@ -231,26 +231,26 @@ class MATRIX_Lattice(AccLattice):
         alpha_arr.append(track_v.get(0))
         beta_arr.append(track_v.get(1))
         for matrixNode in self.getNodes():
-            mt = matrixNode.getMatrix()
-            ind0 = 0 + dir_ind
-            ind1 = 1 + dir_ind
-            track_m.set(0, 0, mt.get(ind0, ind0) * mt.get(ind1, ind1) + mt.get(ind0, ind1) * mt.get(ind1, ind0))
-            track_m.set(0, 1, -mt.get(ind0, ind0) * mt.get(ind1, ind0))
-            track_m.set(0, 2, -mt.get(ind0, ind1) * mt.get(ind1, ind1))
-            track_m.set(1, 0, -2 * mt.get(ind0, ind0) * mt.get(ind0, ind1))
-            track_m.set(1, 1, mt.get(ind0, ind0) * mt.get(ind0, ind0))
-            track_m.set(1, 2, mt.get(ind0, ind1) * mt.get(ind0, ind1))
-            track_m.set(2, 0, -2 * mt.get(ind1, ind0) * mt.get(ind1, ind1))
-            track_m.set(2, 1, mt.get(ind1, ind0) * mt.get(ind1, ind0))
-            track_m.set(2, 2, mt.get(ind1, ind1) * mt.get(ind1, ind1))
-            alpha_0 = track_v.get(0)
-            beta_0 = track_v.get(1)
-            delta_phi = math.atan(mt.get(ind0, ind1) / (beta_0 * mt.get(ind0, ind0) - alpha_0 * mt.get(ind0, ind1)))
-            phi = phi + delta_phi
-            track_v = track_m.mult(track_v)
-            position = position + matrixNode.getLength()
             if isinstance(matrixNode, BaseMATRIX) == True:
                 # only the main nodes are used, the or-cases deal with markers with zero length
+                mt = matrixNode.getMatrix()
+                ind0 = 0 + dir_ind
+                ind1 = 1 + dir_ind
+                track_m.set(0, 0, mt.get(ind0, ind0) * mt.get(ind1, ind1) + mt.get(ind0, ind1) * mt.get(ind1, ind0))
+                track_m.set(0, 1, -mt.get(ind0, ind0) * mt.get(ind1, ind0))
+                track_m.set(0, 2, -mt.get(ind0, ind1) * mt.get(ind1, ind1))
+                track_m.set(1, 0, -2 * mt.get(ind0, ind0) * mt.get(ind0, ind1))
+                track_m.set(1, 1, mt.get(ind0, ind0) * mt.get(ind0, ind0))
+                track_m.set(1, 2, mt.get(ind0, ind1) * mt.get(ind0, ind1))
+                track_m.set(2, 0, -2 * mt.get(ind1, ind0) * mt.get(ind1, ind1))
+                track_m.set(2, 1, mt.get(ind1, ind0) * mt.get(ind1, ind0))
+                track_m.set(2, 2, mt.get(ind1, ind1) * mt.get(ind1, ind1))
+                alpha_0 = track_v.get(0)
+                beta_0 = track_v.get(1)
+                delta_phi = math.atan(mt.get(ind0, ind1) / (beta_0 * mt.get(ind0, ind0) - alpha_0 * mt.get(ind0, ind1)))
+                phi = phi + delta_phi
+                track_v = track_m.mult(track_v)
+                position = position + matrixNode.getLength()
                 # print position, matrixNode.getParam("matrix_parent_node_active_index") == 1
                 # print position, matrixNode.getName(), track_v.get(1)
 


### PR DESCRIPTION
Our colleague Sofia Johannesson found a bug in the matching routine when using a lattice with RF cavities.

I traced the bug to this change in `TEAPOT_MATRIX_Lattice`:
https://github.com/PyORBIT-Collaboration/py-orbit/commit/20eb9af471ec3f67a3d53f004db178f071634a46

Since the method to calculate Twiss parameters in `TEAPOT_MATRIX_Lattice` is also used in the orbit correction and the bumps routines, I assume they are also affected by the bug.

This PR reverts the change that caused the bug.