### PR TITLE
Method adaptorForString(txt) has been added to XmlDataAdaptor

### DIFF
--- a/py/orbit/utils/xml/XmlDataAdaptor.py
+++ b/py/orbit/utils/xml/XmlDataAdaptor.py
@@ -230,6 +230,14 @@ class XmlDataAdaptor(NamedObject, ParamsDictObject):
         xml_root_adaptor = XmlDataAdaptor(root.tag)
         XmlDataAdaptor._makeDataAdaptor(xml_root_adaptor, root)
         return xml_root_adaptor
+        
+    @staticmethod
+    def adaptorForString(txt):
+        """returns the new data adaptor created from the input text"""
+        root = ET.fromstring(txt)
+        xml_root_adaptor = XmlDataAdaptor(root.tag)
+        XmlDataAdaptor._makeDataAdaptor(xml_root_adaptor, root)
+        return xml_root_adaptor
 
     @staticmethod
     def _makeDataAdaptor(data_adaptor, dom_node):


### PR DESCRIPTION
The static method adaptorForString(txt) was added to XmlDataAdaptor class. It creates data adaptor tree from a plain text representation of XML file.