### PR TITLE
Enable toggling space charge node calculation on/off

### DIFF
--- a/py/orbit/space_charge/scAccNodes.py
+++ b/py/orbit/space_charge/scAccNodes.py
@@ -50,7 +50,7 @@ class SC_Base_AccNode(AccNodeBunchTracker):
         """
         Sets the boolean parameter that define if the calculations will be performed. True of False.
         """
-        self.switcher = True
+        self.switcher = switcher
 
     def getCalculationOn(self):
         """


### PR DESCRIPTION
This method `setCalculationOn(switcher: bool) -> None` is inherited by all space charge nodes. Currently it always turns on space charge calculation; it sets class variable `switcher` to True. Maybe should rename this method?