### PR TITLE
Typo in ThickKick class in py/orbit/py_linac/lattice/LinacAccNodes.py

### DIFF
--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -791,7 +791,7 @@ class ThickKick(LinacMagnetNode):
         """
         LinacMagnetNode.__init__(self, name)
         self.addParam("Bx", 0.0)
-        self.addParam("By", [])
+        self.addParam("By", 0.0)
         self.setnParts(1)
         self.setType("thickKick")
 


### PR DESCRIPTION
Initialization of the By parameter should be 0 field. It was [] empty list.