### PR TITLE
Make getNodeForName method match entire name

### DIFF
--- a/py/orbit/lattice/AccLattice.py
+++ b/py/orbit/lattice/AccLattice.py
@@ -117,7 +117,7 @@ class AccLattice(NamedObject, TypedObject):
         """
         nodes = []
         for node in self.__children:
-            if node.getName().find(name) == 0:
+            if node.getName() == name:
                 nodes.append(node)
         if len(nodes) == 1:
             return nodes[0]


### PR DESCRIPTION
Currently `getNodeForName(name)` returns `node` if `node.getName().find(name) == 0`. This throws an error if there is another node with the same prefix. For example:

```python
names = ["QH10", "QH10A", "QH10B"]
for name in names:
    print(name, name.find("QH10"))
```
``` 
QH10 0
QH10A 0
QH10B 0
```
Is this intended behavior?