### PR TITLE
Reduce frequency of flushes of the output buffer in `Bunch::print` and `SyncParticle::print`

### DIFF
--- a/src/orbit/Bunch.cc
+++ b/src/orbit/Bunch.cc
@@ -893,8 +893,6 @@ int Bunch::getCapacity(){
 
 void Bunch::print(std::ostream& Out)
 {
-  int N_flush = 10000;
-
   //single CPU case
   if(rank_MPI == 0){
 
@@ -905,7 +903,7 @@ void Bunch::print(std::ostream& Out)
       ParticleAttributes* attrCntr = *pos;
       Out << attrCntr->name()<<" ";
     }
-    Out << std::endl;
+    Out << '\n';
 
     for (pos = attrCntrVect.begin(); pos != attrCntrVect.end(); ++pos) {
       ParticleAttributes* attrCntr = *pos;
@@ -918,7 +916,7 @@ void Bunch::print(std::ostream& Out)
                     double val = params_pos->second;
                     Out << name <<" " << val << " ";
                 }
-                Out << std::endl;
+                Out << '\n';
             }
         }
 
@@ -927,13 +925,13 @@ void Bunch::print(std::ostream& Out)
     bunchAttr->getIntAttributeNames(bunch_attr_names);
     for(int i = 0, n = bunch_attr_names.size(); i < n; i++){
       Out << "% BUNCH_ATTRIBUTE_INT "<<bunch_attr_names[i]<<"   ";
-      Out << bunchAttr->intVal(bunch_attr_names[i]) <<" "<< std::endl;
+      Out << bunchAttr->intVal(bunch_attr_names[i]) <<" "<< '\n';
     }
     bunch_attr_names.clear();
     bunchAttr->getDoubleAttributeNames(bunch_attr_names);
     for(int i = 0, n = bunch_attr_names.size(); i < n; i++){
       Out << "% BUNCH_ATTRIBUTE_DOUBLE "<<bunch_attr_names[i]<<"   ";
-      Out << bunchAttr->doubleVal(bunch_attr_names[i]) <<" "<< std::endl;
+      Out << bunchAttr->doubleVal(bunch_attr_names[i]) <<" "<< '\n';
     }
 
         //print synchronous particle parameters to the stream
@@ -946,7 +944,7 @@ void Bunch::print(std::ostream& Out)
       Out << attrCntr->attrDescription()<<" ";
     }
 
-    Out << std::endl;
+    Out << '\n';
 
     Out <<std::setprecision(8); //<< std::setiosflags(ios::scientific);
 
@@ -967,12 +965,9 @@ void Bunch::print(std::ostream& Out)
           Out << getParticleAttributeVal(i,j)  <<" ";
         }
 
-        Out <<std::endl;
+        Out <<'\n';
       }
-
-      if (i % N_flush == 0){Out.flush();}
     }
-    Out.flush();
     if(size_MPI == 1) return;
   }
 
@@ -1046,16 +1041,13 @@ void Bunch::print(std::ostream& Out)
               Out<<   dump_arr[(nDimAndAttr)*j + 7 + k] << " ";
             }
 
-            Out << std::endl;
+            Out << '\n';
           }
-
-          if (j % N_flush == 0){ Out.flush();}
         }
       }
     }
   }
 
-  if(rank_MPI == 0){Out.flush();}
     BufferStore::getBufferStore()->setUnusedIntArr(buff_index0);
     BufferStore::getBufferStore()->setUnusedIntArr(buff_index1);
     BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index2);

--- a/src/orbit/SyncPart.cc
+++ b/src/orbit/SyncPart.cc
@@ -488,7 +488,7 @@ void SyncPart::print(std::ostream& Out)
 		Out << getY()  <<" ";
 		Out << getZ()  <<" ";
 		Out <<" x, y, z positions in [m]";
-    Out << std::endl;
+    Out << '\n';
 
     //print momentum
     Out << "%  SYNC_PART_MOMENTUM ";
@@ -496,7 +496,7 @@ void SyncPart::print(std::ostream& Out)
 		Out << getPY()  <<" ";
 		Out << getPZ()  <<" ";
 		Out <<" px, py, pz momentum component in GeV/c";
-    Out << std::endl;
+    Out << '\n';
 
     //print x-axis ort
     Out << "%  SYNC_PART_X_AXIS ";
@@ -504,35 +504,33 @@ void SyncPart::print(std::ostream& Out)
 		Out << getNormalXY()  <<" ";
 		Out << getNormalXZ()  <<" ";
 		Out <<" nxx, nxy, pxz - x-axis ort coordinates";
-    Out << std::endl;
+    Out << '\n';
 
     //print energy
     Out << "%  info only: energy of the synchronous particle [GeV] = ";
 		Out << getEnergy()  <<" ";
-    Out << std::endl;
+    Out << '\n';
 
     //print momentum
     Out << "%  info only: momentum of the synchronous particle [GeV/c] = ";
 		Out << getMomentum()  <<" ";
-    Out << std::endl;
+    Out << '\n';
 
     //print beta
     Out << "%  info only: beta=v/c of the synchronous particle = ";
 		Out << getBeta()  <<" ";
-    Out << std::endl;
+    Out << '\n';
 
     //print gamma
     Out << "%  info only: gamma=1/sqrt(1-(v/c)**2) of the synchronous particle = ";
 		Out << getGamma()  <<" ";
-    Out << std::endl;
+    Out << '\n';
 
     //print time
     Out << "%  SYNC_PART_TIME ";
 		Out << getTime()  <<" ";
 		Out <<" time in [sec]";
-    Out << std::endl;
+    Out << '\n';
   }
-
-  if(rank_MPI == 0){Out.flush();}
   // ===== MPI end =====
 }


### PR DESCRIPTION
Per suggestions from @shishlo, I investigated the frequency that `Bunch::print` would flush the output buffer. This PR replaces all instances of `std::endl` with `'\n'`, as the former invokes a flush operation for each line written to the output file. For very large bunches, this substantially inflates write times. I've also removed manual flushes of the output buffer, as it is flushed automatically when the buffer is full anyway. 

In testing with a bunch size of `N=100_000_000`, with MPI enabled and utilizing 8 cores, I observe these changes to reduce bunch write time by 60-70% across several trials, with no significant increase in RAM consumption relative to the existing implementation.

As an aside, I experimented with pre-allocating the output buffer with various sizes ranging from `64kB` to `16384 kB`, while also varying the `chunkSize` controlling the amount of data communicated to the rank 0 process at once. Neither seemed to yield any further decrease in write times.