### PR TITLE
The typo in the names of the RF Cavity class methods is fixed

### DIFF
--- a/examples/SNS_Linac/rf_quad_overlapping_fields/rfgap_model_longitudinal_test.py
+++ b/examples/SNS_Linac/rf_quad_overlapping_fields/rfgap_model_longitudinal_test.py
@@ -127,7 +127,7 @@ three_point_gap.getRF_Cavity().setPhase(0.)
 bunch = Bunch()
 bunch_init.copyEmptyBunchTo(bunch)
 three_point_gap.trackDesignBunch(bunch)
-cav_1st_gap_entr_phase0 = three_point_gap.getRF_Cavity().getFirstGapEtnrancePhase()
+cav_1st_gap_entr_phase0 = three_point_gap.getRF_Cavity().getFirstGapEntrancePhase()
 
 print ("=============================================================")
 print ("Case 1: Cavity phase scan assuming the phase at z=0 position.")
@@ -144,7 +144,7 @@ for ind in range(Nph+1):
     bunch_init.copyEmptyBunchTo(bunch)
     three_point_gap.trackDesignBunch(bunch)
     
-    cav_1st_gap_entr_phase = phaseNearTargetPhase(three_point_gap.getRF_Cavity().getFirstGapEtnrancePhase(),0.)
+    cav_1st_gap_entr_phase = phaseNearTargetPhase(three_point_gap.getRF_Cavity().getFirstGapEntrancePhase(),0.)
     delta_phase = phaseNearTargetPhase(cav_1st_gap_entr_phase - cav_phase - cav_1st_gap_entr_phase0,0.)
     gap_phase = phaseNearTargetPhase(three_point_gap.getGapPhase(),cav_phase)
     delta_eKin_out = bunch.getSyncParticle().kinEnergy() - Ekin_init
@@ -182,7 +182,7 @@ three_point_gap.getRF_Cavity().setPhase(0.)
 bunch = Bunch()
 bunch_init.copyEmptyBunchTo(bunch)
 three_point_gap.trackDesignBunch(bunch)
-cav_1st_gap_entr_phase0 = three_point_gap.getRF_Cavity().getFirstGapEtnrancePhase()
+cav_1st_gap_entr_phase0 = three_point_gap.getRF_Cavity().getFirstGapEntrancePhase()
 
 print ("=============================================================")
 print ("Case 2: Cavity phase scan assuming the phase at the entrance.")
@@ -199,7 +199,7 @@ for ind in range(Nph+1):
     bunch_init.copyEmptyBunchTo(bunch)
     three_point_gap.trackDesignBunch(bunch)
     
-    cav_1st_gap_entr_phase = phaseNearTargetPhase(three_point_gap.getRF_Cavity().getFirstGapEtnrancePhase(),0.)
+    cav_1st_gap_entr_phase = phaseNearTargetPhase(three_point_gap.getRF_Cavity().getFirstGapEntrancePhase(),0.)
     delta_phase = phaseNearTargetPhase(cav_1st_gap_entr_phase - cav_phase - cav_1st_gap_entr_phase0,0.)
     gap_phase = phaseNearTargetPhase(three_point_gap.getGapPhase(),cav_phase)
     delta_eKin_out = bunch.getSyncParticle().kinEnergy() - Ekin_init

--- a/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
+++ b/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
@@ -424,19 +424,19 @@ class RF_Cavity(NamedObject, ParamsDictObject):
         """Returns the phase for the first RF gap."""
         return self.getParam("phase")
 
-    def setFirstGapEtnrancePhase(self, phase):
+    def setFirstGapEntrancePhase(self, phase):
         """Sets the phase at the first gap entrance if Length_of_gap > 0."""
         self.__firstGapEntrancePhase = phase
 
-    def getFirstGapEtnrancePhase(self):
+    def getFirstGapEntrancePhase(self):
         """Returns the phase at the first gap entrance if Length_of_gap > 0."""
         return self.__firstGapEntrancePhase
 
-    def setFirstGapEtnranceDesignPhase(self, phase):
+    def setFirstGapEntranceDesignPhase(self, phase):
         """Sets the design phase at the first gap entrance if Length_of_gap > 0."""
         self.__firstGapEntranceDesignPhase = phase
 
-    def getFirstGapEtnranceDesignPhase(self):
+    def getFirstGapEntranceDesignPhase(self):
         """Returns the design phase at the first gap entrance if Length_of_gap > 0."""
         return self.__firstGapEntranceDesignPhase
 

--- a/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
+++ b/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
@@ -301,7 +301,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
         arrival_time = syncPart.time()
         designArrivalTime = rfCavity.getDesignArrivalTime()
         phase_shift = rfCavity.getPhase() - rfCavity.getDesignPhase()
-        phase = rfCavity.getFirstGapEtnrancePhase() + phase_shift
+        phase = rfCavity.getFirstGapEntrancePhase() + phase_shift
         usePhaseAtEntrance = rfCavity.getUsePhaseAtEntrance()
         if(usePhaseAtEntrance):
             phase = rfCavity.getPhase()        
@@ -442,7 +442,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
         rf_ampl = rfCavity.getDesignAmp()
         arrival_time = syncPart.time()
         frequency = rfCavity.getFrequency()
-        phase = rfCavity.getFirstGapEtnrancePhase()
+        phase = rfCavity.getFirstGapEntrancePhase()
         usePhaseAtEntrance = rfCavity.getUsePhaseAtEntrance()
         if(usePhaseAtEntrance):
             phase = rfCavity.getPhase()
@@ -451,8 +451,8 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
             rfCavity.setDesignArrivalTime(arrival_time)
             if(not usePhaseAtEntrance):           
                 phase = self.axis_field_rf_gap.calculate_first_part_phase(bunch)
-            rfCavity.setFirstGapEtnrancePhase(phase)
-            rfCavity.setFirstGapEtnranceDesignPhase(phase)
+            rfCavity.setFirstGapEntrancePhase(phase)
+            rfCavity.setFirstGapEntranceDesignPhase(phase)
             rfCavity.setDesignSetUp(True)
             rfCavity._setDesignPhase(rfCavity.getPhase())
             rfCavity._setDesignAmp(rfCavity.getAmp())

--- a/py/orbit/py_linac/lattice/LinacRfGapNodes.py
+++ b/py/orbit/py_linac/lattice/LinacRfGapNodes.py
@@ -268,8 +268,8 @@ class BaseRF_Gap(AbstractRF_Gap):
         if self.__isFirstGap:
             rfCavity.setDesignArrivalTime(arrival_time)
             rfCavity.setDesignSetUp(True)
-            rfCavity.setFirstGapEtnrancePhase(rfCavity.getPhase())
-            rfCavity.setFirstGapEtnranceDesignPhase(rfCavity.getPhase())
+            rfCavity.setFirstGapEntrancePhase(rfCavity.getPhase())
+            rfCavity.setFirstGapEntranceDesignPhase(rfCavity.getPhase())
             rfCavity._setDesignPhase(rfCavity.getPhase())
             rfCavity._setDesignAmp(rfCavity.getAmp())
         else:
@@ -616,7 +616,7 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
         arrival_time = syncPart.time()
         designArrivalTime = rfCavity.getDesignArrivalTime()
         phase_shift = rfCavity.getPhase() - rfCavity.getDesignPhase()
-        phase = rfCavity.getFirstGapEtnrancePhase() + phase_shift
+        phase = rfCavity.getFirstGapEntrancePhase() + phase_shift
         usePhaseAtEntrance = rfCavity.getUsePhaseAtEntrance()
         if(usePhaseAtEntrance):
             phase = rfCavity.getPhase()
@@ -714,7 +714,7 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
         rf_ampl = rfCavity.getDesignAmp()
         arrival_time = syncPart.time()
         frequency = rfCavity.getFrequency()
-        phase = rfCavity.getFirstGapEtnrancePhase()
+        phase = rfCavity.getFirstGapEntrancePhase()
         usePhaseAtEntrance = rfCavity.getUsePhaseAtEntrance()
         if(usePhaseAtEntrance):
             phase = rfCavity.getPhase()
@@ -723,8 +723,8 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
             rfCavity.setDesignArrivalTime(arrival_time)
             if(not usePhaseAtEntrance):
                 phase = self.__calculate_first_part_phase(bunch)
-            rfCavity.setFirstGapEtnrancePhase(phase)
-            rfCavity.setFirstGapEtnranceDesignPhase(phase)
+            rfCavity.setFirstGapEntrancePhase(phase)
+            rfCavity.setFirstGapEntranceDesignPhase(phase)
             rfCavity.setDesignSetUp(True)
             rfCavity._setDesignPhase(rfCavity.getPhase())
             rfCavity._setDesignAmp(rfCavity.getAmp())


### PR DESCRIPTION
The typo in the names of the RF Cavity class methods is fixed:  GapEtnrance replaced by GapEntrance