### PR TITLE
Control number of FFT modes in longitudinal space charge solver

### DIFF
--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -6,33 +6,25 @@ import sys
 import os
 import math
 
-# import the function that finalizes the execution
-from orbit.utils import orbitFinalize
-
-# import physical constants
-from orbit.utils import consts
-
-# import general accelerator elements and lattice
-from orbit.lattice import AccLattice, AccNode, AccActionsContainer, AccNodeBunchTracker
-
-# import teapot drift class
-from orbit.teapot import DriftTEAPOT
-
-# import longitudinal space charge package
+from orbit.core.bunch import Bunch
 from orbit.core.spacecharge import LSpaceChargeCalc
-
-# -----------------------------------------------------------------------------
-# Node for impedance as function of node number
-# -----------------------------------------------------------------------------
+from orbit.lattice import AccLattice
+from orbit.lattice import AccNode
+from orbit.lattice import AccActionsContainer
+from orbit.lattice import AccNodeBunchTracker
+from orbit.utils import consts
+from orbit.utils import orbitFinalize
+from orbit.teapot import DriftTEAPOT
 
 
 class SC1D_AccNode(DriftTEAPOT):
-    def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, name="long sc node"):
+    """Longitudinal space charge node."""
+    def __init__(self, b_a: float, phase_length: float, nmacros_min: float, use_sc: float, nbins: float, nfreq: int = -1, name="long sc node"):
         """
         Constructor. Creates the SC1D-teapot element.
         """
         DriftTEAPOT.__init__(self, name)
-        self.lspacecharge = LSpaceChargeCalc(b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins)
+        self.lspacecharge = LSpaceChargeCalc(b_a, phase_length, nmacros_min, use_sc, nbins, nfreq)
         self.setType("long sc node")
         self.setLength(0.0)
 
@@ -51,18 +43,14 @@ class SC1D_AccNode(DriftTEAPOT):
         """
         length = self.getLength(self.getActivePartIndex())
         bunch = paramsDict["bunch"]
-        self.lspacecharge.trackBunch(bunch)  # track method goes here
+        self.lspacecharge.trackBunch(bunch)
 
     def assignImpedance(self, py_cmplx_arr):
         self.lspacecharge.assignImpedance(py_cmplx_arr)
 
 
-# -----------------------------------------------------------------------------
-# Node for impedance as function of frequency
-# -----------------------------------------------------------------------------
-
-
 class FreqDep_SC1D_AccNode(DriftTEAPOT):
+    """Longitudinal space charge node (frequency-dependent)."""
     def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, bunch, impeDict, name="freq. dep. long sc node"):
         """
         Constructor. Creates the FreqDep_SC1D-teapot element.
@@ -121,12 +109,8 @@ class FreqDep_SC1D_AccNode(DriftTEAPOT):
         self.lspacecharge.trackBunch(bunch)
 
 
-# -----------------------------------------------------------------------------
-# Node for impedance as function of beta and frequency
-# -----------------------------------------------------------------------------
-
-
 class BetFreqDep_SC1D_AccNode(DriftTEAPOT):
+    """Longitudinal space charge node (frequency- and velocity-dependent)."""
     def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, bunch, impeDict, name="freq. dep. long sc node"):
         """
         Constructor. Creates the BetFreqDep_SC1D-teapot element.

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -27,8 +27,6 @@ class SC1D_AccNode(DriftTEAPOT):
         nmacros_min: float,
         use_sc: float,
         nbins: float,
-        nmodes: int = None,
-        use_grad: bool = False,
         name="long sc node",
     ) -> None:
         """
@@ -36,8 +34,6 @@ class SC1D_AccNode(DriftTEAPOT):
         """
         DriftTEAPOT.__init__(self, name)
         self.lspacecharge = LSpaceChargeCalc(b_a, phase_length, nmacros_min, use_sc, nbins)
-        self.setNumModes(nmodes)
-        # self.setUseGrad(use_grad)
         self.setType("long sc node")
         self.setLength(0.0)
 

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -37,9 +37,13 @@ class SC1D_AccNode(DriftTEAPOT):
         self.setType("long sc node")
         self.setLength(0.0)
 
-    def setUseGrad(self, use_grad: bool) -> None:
+    def setUseGrad(self, setting: bool) -> None:
         """Sets whether to use gradient-based solver instead of impedance solver."""
-        self.lspacecharge.setUseGrad(int(use_grad))
+        self.lspacecharge.setUseGrad(int(setting))
+
+    def setSmoothGrad(self, setting: bool) -> None:
+        """Sets whether to use smoothed gradient."""
+        self.lspacecharge.setSmoothGrad(int(setting))
 
     def setNumModes(self, n: int) -> None:
         """Sets number of FFT modes used to calculate energy kick."""

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -106,7 +106,7 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
     if (nPartsGlobal < nMacrosMin)
         return;
 
-    // Bin the particles
+    // Bin the particles.
     double zmin, zmax;
     double realPart, imagPart;
 
@@ -119,101 +119,70 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
     zGrid->binBunchSmoothedByParticle(bunch);
     zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
 
-    if (useGrad == 0) {  // Impedance-based solver
+    // FFT the beam density.
+    for (int i = 0; i < nBins; i++) {
+        _in[i][0] = zGrid->getValueOnGrid(i);
+        _in[i][1] = 0.;
+    }
 
-        // FFT the beam density
-        for (int i = 0; i < nBins; i++) {
-            _in[i][0] = zGrid->getValueOnGrid(i);
-            _in[i][1] = 0.;
-        }
+    fftw_execute(_plan);
 
-        fftw_execute(_plan);
+    // Find the magnitude and phase
+    _fftmagnitude[0] = _out[0][0] / (double)nBins;
+    _fftphase[0] = 0.;
 
-        // Find the magnitude and phase
-        _fftmagnitude[0] = _out[0][0] / (double)nBins;
-        _fftphase[0] = 0.;
+    for (int n = 1; n < nBins / 2; n++) {
+        realPart = _out[n][0] / ((double)nBins);
+        imagPart = _out[n][1] / ((double)nBins);
+        _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
+        _fftphase[n] = atan2(imagPart, realPart);
+    }
 
-        for (int n = 1; n < nBins / 2; n++) {
-            realPart = _out[n][0] / ((double)nBins);
-            imagPart = _out[n][1] / ((double)nBins);
-            _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
-            _fftphase[n] = atan2(imagPart, realPart);
-        }
+    // Space charge contribution to impedance.
+    SyncPart *sp = bunch->getSyncPart();
 
-        // Space charge contribution to impedance
-        SyncPart *sp = bunch->getSyncPart();
+    // Set zero if useSpaceCharge = 0.
+    double zSpaceCharge_n = 0.;
 
-        // Set zero if useSpaceCharge = 0
-        double zSpaceCharge_n = 0.;
+    // Otherwise, set positive since space charge is capacitive (Chao convention).
+    if (useSpaceCharge != 0) {
+        double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
+        double _z_0 = OrbitConst::c * mu_0;
 
-        // Otherwise, set positive since space charge is capacitive (Chao convention)
-        if (useSpaceCharge != 0) {
-            double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
-            double _z_0 = OrbitConst::c * mu_0;
+        zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
+                         (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
+    }
 
-            zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
-                             (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
-        }
+    for (int n = 1; n < nBins / 2; n++) {
+        realPart = std::real(_zImped_n[n]);
+        imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
+        _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
+        _chi[n] = atan2(imagPart, realPart);
+    }
 
-        for (int n = 1; n < nBins / 2; n++) {
-            realPart = std::real(_zImped_n[n]);
-            imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
-            _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
-            _chi[n] = atan2(imagPart, realPart);
-        }
+    // Convert charge to current for a single macroparticle per unit bin length.
+    double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
 
-        // Convert charge to current for a single macroparticle per unit bin length
-        double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
+    // Calculate and add the kick to macroparticles.
+    double kick, angle, position;
 
-        // Calculate and add the kick to macroparticles
-        double kick, angle, position;
+    // Convert particle longitudinal coordinate to phi.
+    double philocal;
+    double z;
+    double **coords = bunch->coordArr();
+    for (int j = 0; j < bunch->getSize(); j++) {
+        z = bunch->z(j);
+        philocal = (z / length) * 2 * OrbitConst::PI;
 
-        // Convert particle longitudinal coordinate to phi
-        double philocal;
-        double z;
-        double **coords = bunch->coordArr();
-        for (int j = 0; j < bunch->getSize(); j++) {
-            z = bunch->z(j);
-            philocal = (z / length) * 2 * OrbitConst::PI;
+        // Handle cases where the longitudinal coordinate is
+        // outside of the user-specified length
+        if (philocal < -OrbitConst::PI)
+            philocal += 2 * OrbitConst::PI;
+        if (philocal > OrbitConst::PI)
+            philocal -= 2 * OrbitConst::PI;
 
-            // Handle cases where the longitudinal coordinate is
-            // outside of the user-specified length
-            if (philocal < -OrbitConst::PI)
-                philocal += 2 * OrbitConst::PI;
-            if (philocal > OrbitConst::PI)
-                philocal -= 2 * OrbitConst::PI;
-
-            double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-            coords[j][5] += dE;
-        }
-    } 
-    else {  // Gradient-based solver
-        double pi = OrbitConst::PI;
-        double c = OrbitConst::c;
-        double mu0 = OrbitConst::permeability;
-        double eps0 = 1.0 / (mu0 * c * c);
-        double g = (1.0 + 2.0 * log(b_a));
-        double q = bunch->getCharge();
-
-        SyncPart *sp = bunch->getSyncPart();
-        double beta = sp->getBeta();
-        double gamma = sp->getGamma();
-
-        double ez_factor = g * q / (4.0 * pi * eps0 * gamma * gamma);
-        double kick_factor = length * bunch->getClassicalRadius() * bunch->getMass();
-
-        double z, ez, density_gradient;
-        for (int i = 0, n = bunch->getSize(); i < n; i++) {
-            z = bunch->z(i) * gamma;
-            if (smooth > 0) {
-                zGrid->calcGradientSmoothed(z, density_gradient);
-            }
-            else {
-                zGrid->calcGradient(z, density_gradient);
-            }
-            ez = density_gradient * ez_factor;
-            bunch->dE(i) -= ez * kick_factor;
-        }
+        double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
+        coords[j][5] += dE;
     }
 }
 

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -184,9 +184,38 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
         }
     } 
     else {
-        std::cout << "Gradient-based solver is not implemented.";
+        double pi = OrbitConst::PI;
+        double c = OrbitConst::c;
+        double mu0 = OrbitConst::permeability;
+        double eps0 = 1.0 / (mu0 * c * c);
+        double g = (1.0 + 2.0 * log(b_a));
+        double q = bunch->getCharge();
+
+        SyncPart *sp = bunch->getSyncPart();
+        double beta = sp->getBeta();
+        double gamma = sp->getGamma();
+        double ez_factor = g * q / (4.0 * pi * eps0 * gamma * gamma);
+
+        double kick_factor = length * bunch->getClassicalRadius() * bunch->getMass();
+
+        int smooth = 1;
+
+        double z, ez, density_gradient;
+        for (int i = 0, n = bunch->getSize(); i < n; i++) {
+            z = bunch->z(i) * gamma;
+            if (smooth > 0) {
+                zGrid->calcGradientSmoothed(z, density_gradient);
+            }
+            else {
+                zGrid->calcGradient(z, density_gradient);
+            }
+            ez = density_gradient * ez_factor;
+            bunch->dE(i) -= ez * kick_factor;
+        }
     }
 }
+
+
 
 ///////////////////////////////////////////////////////////////////////////
 //

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -11,194 +11,182 @@
 //
 /////////////////////////////////////////////////////////////////////////////
 
-#include "Grid1D.hh"
-#include "BufferStore.hh"
 #include "LSpaceChargeCalc.hh"
+#include "BufferStore.hh"
+#include "Grid1D.hh"
 #include "OrbitConst.hh"
+#include <cfloat>
+#include <cmath>
 #include <complex>
 #include <iostream>
-#include <cmath>
-#include <cfloat>
-#include <complex>
 
-//FFTW library header
+// FFTW library header
 #include "fftw3.h"
 
 using namespace OrbitUtils;
 
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in) : CppPyWrapper(NULL) {
+    b_a = b_a_in;
+    length = length_in;
+    nMacrosMin = nMacrosMin_in;
+    useSpaceCharge = useSpaceCharge_in;
+    nBins = nBins_in;
+    zGrid = new Grid1D(nBins, length);
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
-{
-  b_a            = b_a_in;
-  length         = length_in;
-  nMacrosMin     = nMacrosMin_in;
-  useSpaceCharge = useSpaceCharge_in;
-  nBins          = nBins_in;
-  zGrid          = new Grid1D(nBins, length);
-    
-  nModes = nBins / 2;
-  useGrad = 0;
+    nModes = nBins / 2;
+    useGrad = 0;
 
-  _fftmagnitude  = new double[nBins / 2];
-  _fftphase      = new double[nBins / 2];
-  _z             = new double[nBins / 2];
-  _chi           = new double[nBins / 2];
-  //---------------------------
-  // _zImped_n size was increased by 1 to avoid crash due to
-  // assignment in LSpaceChargeCalc::assignImpedanceValue(...)
-  // to _zImped_n[n + 1] element. This should be resolved later.
-  //----------------------------
-  _zImped_n      = new std::complex<double>[nBins / 2 + 1];
+    _fftmagnitude = new double[nBins / 2];
+    _fftphase = new double[nBins / 2];
+    _z = new double[nBins / 2];
+    _chi = new double[nBins / 2];
+    //---------------------------
+    // _zImped_n size was increased by 1 to avoid crash due to
+    // assignment in LSpaceChargeCalc::assignImpedanceValue(...)
+    // to _zImped_n[n + 1] element. This should be resolved later.
+    //----------------------------
+    _zImped_n = new std::complex<double>[nBins / 2 + 1];
 
-  for(int n = 0; n < nBins / 2; n++)
-  {
-    _fftmagnitude[n] = 0.0;
-    _fftphase[n]     = 0.0;
-    _z[n]            = 0.0;
-    _chi[n]          = 0.0;
-    _zImped_n[n] = std::complex<double>(0.0, 0.0);
-  }
+    for (int n = 0; n < nBins / 2; n++) {
+        _fftmagnitude[n] = 0.0;
+        _fftphase[n] = 0.0;
+        _z[n] = 0.0;
+        _chi[n] = 0.0;
+        _zImped_n[n] = std::complex<double>(0.0, 0.0);
+    }
 
-  _in   = (fftw_complex *) fftw_malloc(nBins * sizeof(fftw_complex));
-  _out  = (fftw_complex *) fftw_malloc(nBins * sizeof(fftw_complex));
-  _plan = fftw_plan_dft_1d(nBins, _in,  _out, FFTW_FORWARD, FFTW_ESTIMATE);
+    _in = (fftw_complex *)fftw_malloc(nBins * sizeof(fftw_complex));
+    _out = (fftw_complex *)fftw_malloc(nBins * sizeof(fftw_complex));
+    _plan = fftw_plan_dft_1d(nBins, _in, _out, FFTW_FORWARD, FFTW_ESTIMATE);
 }
 
-
-LSpaceChargeCalc::~LSpaceChargeCalc()
-{
-  if(zGrid->getPyWrapper() != NULL)
-  {
-    Py_DECREF(zGrid->getPyWrapper());
-  }
-  else
-  {
-    delete zGrid;
-  }
-  delete[] _fftmagnitude;
-  delete[] _fftphase;
-  delete[] _z;
-  delete[] _chi;
-  delete[] _zImped_n;
-  fftw_free(_in);
-  fftw_free(_out);
-  fftw_destroy_plan(_plan);
+LSpaceChargeCalc::~LSpaceChargeCalc() {
+    if (zGrid->getPyWrapper() != NULL) {
+        Py_DECREF(zGrid->getPyWrapper());
+    } else {
+        delete zGrid;
+    }
+    delete[] _fftmagnitude;
+    delete[] _fftphase;
+    delete[] _z;
+    delete[] _chi;
+    delete[] _zImped_n;
+    fftw_free(_in);
+    fftw_free(_out);
+    fftw_destroy_plan(_plan);
 }
-
 
 void LSpaceChargeCalc::setNumModes(int n) {
-  nModes = n;
-  int nModesMax = nBins / 2;
-    
-  if (nModes > nModesMax) {
-    nModes = nModesMax;
-  }
-  if (nModes < 0) {
-    nModes = nModesMax;
-  }
-}
+    nModes = n;
+    int nModesMax = nBins / 2;
 
+    if (nModes > nModesMax) {
+        nModes = nModesMax;
+    }
+    if (nModes < 0) {
+        nModes = nModesMax;
+    }
+}
 
 void LSpaceChargeCalc::setUseGrad(int setting) {
     useGrad = setting;
 }
 
-
-void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag)
-{
-  _zImped_n[n + 1] = std::complex<double>(real, imag);
+void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag) {
+    _zImped_n[n + 1] = std::complex<double>(real, imag);
 }
 
+void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
+    int nPartsGlobal = bunch->getSizeGlobal();
+    if (nPartsGlobal < nMacrosMin)
+        return;
 
-void LSpaceChargeCalc::trackBunch(Bunch* bunch)
-{
-  int nPartsGlobal = bunch->getSizeGlobal();
-  if(nPartsGlobal < nMacrosMin) return;
+    // Bin the particles
+    double zmin, zmax;
+    double realPart, imagPart;
 
-  // Bin the particles
-  double zmin, zmax;
-  double realPart, imagPart;
+    bunchExtremaCalc->getExtremaZ(bunch, zmin, zmax);
+    double zextra = (length - (zmax - zmin)) / 2.0;
+    zmax += zextra;
+    zmin = zmax - length;
+    zGrid->setGridZ(zmin, zmax);
+    zGrid->setZero();
+    zGrid->binBunchSmoothedByParticle(bunch);
+    zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
 
-  bunchExtremaCalc->getExtremaZ(bunch, zmin, zmax);
-  double zextra = (length - (zmax - zmin)) / 2.0;
-  zmax += zextra;
-  zmin  = zmax - length;
-  zGrid->setGridZ(zmin, zmax);
-  zGrid->setZero();
-  zGrid->binBunchSmoothedByParticle(bunch);
-  zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
+    if (useGrad == 0) {
 
-  // FFT the beam density
-  for(int i = 0; i < nBins; i++)
-  {
-    _in[i][0] = zGrid->getValueOnGrid(i);
-    _in[i][1] = 0.;
-  }
+        // FFT the beam density
+        for (int i = 0; i < nBins; i++) {
+            _in[i][0] = zGrid->getValueOnGrid(i);
+            _in[i][1] = 0.;
+        }
 
-  fftw_execute(_plan);
+        fftw_execute(_plan);
 
-  // Find the magnitude and phase
-  _fftmagnitude[0] = _out[0][0]/(double)nBins;
-  _fftphase[0] = 0.;
+        // Find the magnitude and phase
+        _fftmagnitude[0] = _out[0][0] / (double)nBins;
+        _fftphase[0] = 0.;
 
-  for(int n = 1; n < nBins / 2; n++)
-  {
-    realPart = _out[n][0]/((double)nBins);
-    imagPart = _out[n][1]/((double)nBins);
-    _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
-    _fftphase[n] = atan2(imagPart,realPart);
-  }
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = _out[n][0] / ((double)nBins);
+            imagPart = _out[n][1] / ((double)nBins);
+            _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
+            _fftphase[n] = atan2(imagPart, realPart);
+        }
 
-  // Space charge contribution to impedance
-  SyncPart* sp = bunch->getSyncPart();
+        // Space charge contribution to impedance
+        SyncPart *sp = bunch->getSyncPart();
 
-  // Set zero if useSpaceCharge = 0
-  double zSpaceCharge_n = 0.;
+        // Set zero if useSpaceCharge = 0
+        double zSpaceCharge_n = 0.;
 
-  // Otherwise, set positive since space charge is capacitive (Chao convention)
-  if(useSpaceCharge != 0)
-  {
-    double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
-    double _z_0 = OrbitConst::c * mu_0;
+        // Otherwise, set positive since space charge is capacitive (Chao convention)
+        if (useSpaceCharge != 0) {
+            double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
+            double _z_0 = OrbitConst::c * mu_0;
 
-    zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
-                     (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
-  }
+            zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
+                             (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
+        }
 
-  for(int n = 1; n < nBins / 2; n++)
-  {
-    realPart = std::real(_zImped_n[n]);
-    imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
-    _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
-    _chi[n] = atan2(imagPart, realPart);
-  }
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = std::real(_zImped_n[n]);
+            imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
+            _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
+            _chi[n] = atan2(imagPart, realPart);
+        }
 
-  // Convert charge to current for a single macroparticle per unit bin length
-  double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
+        // Convert charge to current for a single macroparticle per unit bin length
+        double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
 
-  // Calculate and add the kick to macroparticles
-  double kick, angle, position;
+        // Calculate and add the kick to macroparticles
+        double kick, angle, position;
 
-  // Convert particle longitudinal coordinate to phi
+        // Convert particle longitudinal coordinate to phi
 
-  double philocal;
-  double z;
-  double** coords = bunch->coordArr();
-  for (int j = 0; j < bunch->getSize(); j++)
-  {
-    z = bunch->z(j);
-    philocal = (z / length) * 2 * OrbitConst::PI;
+        double philocal;
+        double z;
+        double **coords = bunch->coordArr();
+        for (int j = 0; j < bunch->getSize(); j++) {
+            z = bunch->z(j);
+            philocal = (z / length) * 2 * OrbitConst::PI;
 
-  // Handle cases where the longitudinal coordinate is
-  // outside of the user-specified length
-  if(philocal < -OrbitConst::PI) philocal += 2 * OrbitConst::PI;
-  if(philocal >  OrbitConst::PI) philocal -= 2 * OrbitConst::PI;
+            // Handle cases where the longitudinal coordinate is
+            // outside of the user-specified length
+            if (philocal < -OrbitConst::PI)
+                philocal += 2 * OrbitConst::PI;
+            if (philocal > OrbitConst::PI)
+                philocal -= 2 * OrbitConst::PI;
 
-  double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-  coords[j][5] += dE;
-  }
+            double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
+            coords[j][5] += dE;
+        }
+    } 
+    else {
+        std::cout << "Gradient-based solver is not implemented.";
+    }
 }
-
 
 ///////////////////////////////////////////////////////////////////////////
 //
@@ -217,20 +205,18 @@ void LSpaceChargeCalc::trackBunch(Bunch* bunch)
 //
 ///////////////////////////////////////////////////////////////////////////
 
-double LSpaceChargeCalc::_kick(double angle)
-{
-  // n=0 term has no impact (constant in phi)
-  // f(phi) = _FFTMagnitude(1) + sum (n = 2 -> N / 2) of
-  //          [2 * _FFTMagnitude(i) * cos(phi * (n - 1) +
-  //          _FFTPhase(n) + _chi(n))]
+double LSpaceChargeCalc::_kick(double angle) {
+    // n=0 term has no impact (constant in phi)
+    // f(phi) = _FFTMagnitude(1) + sum (n = 2 -> N / 2) of
+    //          [2 * _FFTMagnitude(i) * cos(phi * (n - 1) +
+    //          _FFTPhase(n) + _chi(n))]
 
-  double kick = 0.;
-  double cosArg;
+    double kick = 0.;
+    double cosArg;
 
-  for(int n = 1; n < nModes; n++)
-  {
-    cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
-    kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);
-  }
-  return kick;
+    for (int n = 1; n < nModes; n++) {
+        cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
+        kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);
+    }
+    return kick;
 }

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -27,7 +27,7 @@
 using namespace OrbitUtils;
 
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in, int nFreq_in): CppPyWrapper(NULL)
 {
   b_a            = b_a_in;
   length         = length_in;
@@ -35,6 +35,7 @@ LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosM
   useSpaceCharge = useSpaceCharge_in;
   nBins          = nBins_in;
   zGrid          = new Grid1D(nBins, length);
+  nFreq = nFreq_in;
 
   _fftmagnitude  = new double[nBins / 2];
   _fftphase      = new double[nBins / 2];

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -27,7 +27,7 @@
 using namespace OrbitUtils;
 
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in, int nFreq_in): CppPyWrapper(NULL)
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
 {
   b_a            = b_a_in;
   length         = length_in;
@@ -36,13 +36,8 @@ LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosM
   nBins          = nBins_in;
   zGrid          = new Grid1D(nBins, length);
     
-  nFreq = nFreq_in;
-  if (nFreq > (nBins / 2)) {
-    nFreq = nBins / 2;
-  }
-  if (nFreq < 0) {
-    nFreq = nBins / 2;
-  }
+  nModes = nBins / 2;
+  useGrad = 0;
 
   _fftmagnitude  = new double[nBins / 2];
   _fftphase      = new double[nBins / 2];
@@ -88,6 +83,24 @@ LSpaceChargeCalc::~LSpaceChargeCalc()
   fftw_free(_in);
   fftw_free(_out);
   fftw_destroy_plan(_plan);
+}
+
+
+void LSpaceChargeCalc::setNumModes(int n) {
+  nModes = n;
+  int nModesMax = nBins / 2;
+    
+  if (nModes > nModesMax) {
+    nModes = nModesMax;
+  }
+  if (nModes < 0) {
+    nModes = nModesMax;
+  }
+}
+
+
+void LSpaceChargeCalc::setUseGrad(int setting) {
+    useGrad = setting;
 }
 
 
@@ -214,7 +227,7 @@ double LSpaceChargeCalc::_kick(double angle)
   double kick = 0.;
   double cosArg;
 
-  for(int n = 1; n < nFreq; n++)
+  for(int n = 1; n < nModes; n++)
   {
     cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
     kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -99,10 +99,6 @@ void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag)
 
 void LSpaceChargeCalc::trackBunch(Bunch* bunch)
 {
-
-  std::cout << "nbins=" << nBins << " nfreq=" << nFreq << std::endl; 
-
-    
   int nPartsGlobal = bunch->getSizeGlobal();
   if(nPartsGlobal < nMacrosMin) return;
 

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -38,7 +38,7 @@ public:
 	void setNumModes(int n);
 
 	/** Sets option to use gradient rather than impedance. **/
-	void setUseGrad(int n);
+	void setUseGrad(int setting);
 
 	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -29,17 +29,21 @@ class LSpaceChargeCalc: public OrbitUtils::CppPyWrapper
 public:
 
 	/** Constructor */
-	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in, int nFreq_in);
+	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in);
 
 	/** Destructor */
 	virtual ~LSpaceChargeCalc();
 
-	/** Calculates space charge and applies the transverse and
-	longitudinal SC kicks to the macro-particles in the bunch. */
+	/** Sets number of FFT modes used to calculate energy kick from impedance. **/
+	void setNumModes(int n);
+
+	/** Sets option to use gradient rather than impedance. **/
+	void setUseGrad(int n);
+
+	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);
 
-	/** Assigns the real and imaginary parts of the
-        machine impedance for index n**/
+	/** Assigns the real and imaginary parts of the machine impedance for index n**/
 	void assignImpedanceValue(int n, double real, double imag);
 
 	/** Routine for calculating the kick to the particle **/
@@ -52,7 +56,8 @@ public:
 	int nBins;
 	int nMacrosMin;
 	int useSpaceCharge;
-    int nFreq;
+    int nModes;
+    int useGrad;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -29,7 +29,7 @@ class LSpaceChargeCalc: public OrbitUtils::CppPyWrapper
 public:
 
 	/** Constructor */
-	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in);
+	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in, int nFreq_in);
 
 	/** Destructor */
 	virtual ~LSpaceChargeCalc();
@@ -52,6 +52,7 @@ public:
 	int nBins;
 	int nMacrosMin;
 	int useSpaceCharge;
+    int nFreq;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -40,6 +40,9 @@ public:
 	/** Sets option to use gradient rather than impedance. **/
 	void setUseGrad(int setting);
 
+	/** Sets option to use smooth gradient of longitudinal density. **/
+	void setSmoothGrad(int setting);
+
 	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);
 
@@ -58,6 +61,7 @@ public:
 	int useSpaceCharge;
     int nModes;
     int useGrad;
+    int smooth;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,8 +46,10 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
+        int nModes;
+        int useGrad;
 
-		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
+		if(!PyArg_ParseTuple(args,"ddiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
 		}
 
@@ -92,37 +94,31 @@ extern "C"
 
 	}
 
-	static PyObject* LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args){
-
+    static PyObject *LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args) {
 		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
 		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
 
-		int n = -1;
-        
-		if(!PyArg_ParseTuple(args,"i:arguments", &n)){
+        int nmodes;
+        if (!PyArg_ParseTuple(args, "i:arguments", &nmodes)) {
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setNumModes(n) - constructor needs parameters.");
-		}
-		cpp_LSpaceChargeCalc->setNumModes(n);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-
-	static PyObject* LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args){
-
+        }
+		cpp_LSpaceChargeCalc->setNumModes(nmodes);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    
+    static PyObject *LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args) {
 		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
 		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
 
-		int setting = 0;
-        
-		if(!PyArg_ParseTuple(args,"i:arguments", &setting)){
+        int usegrad;
+        if (!PyArg_ParseTuple(args, "i:arguments", &usegrad)) {
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setUseGrad(setting) - constructor needs parameters.");
-		}
-		cpp_LSpaceChargeCalc->setUseGrad(setting);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
+        }
+		cpp_LSpaceChargeCalc->setUseGrad(usegrad);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
 
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){
@@ -180,9 +176,11 @@ extern "C"
   // defenition of the methods of the python LSpaceChargeCalc wrapper class
   // they will be vailable from python level
   static PyMethodDef LSpaceChargeCalcClassMethods[] = {
-		{ "trackBunch",  LSpaceChargeCalc_trackBunch, METH_VARARGS,"trackBunch the bunch - trackBunch(pyBunch)"},
-		{ "assignImpedanceValue",  LSpaceChargeCalc_assignImpedanceValue, METH_VARARGS,"assigne the impedance for the ith mode - assignImpedanceValue(i,real,imag)"},
-		{ "assignImpedance",  assignImpedance, METH_VARARGS,"assigne the impedance for the ith mode - assignImpedance(Z))"},
+		{ "trackBunch", LSpaceChargeCalc_trackBunch, METH_VARARGS,"trackBunch the bunch - trackBunch(pyBunch)"},
+		{ "assignImpedanceValue", LSpaceChargeCalc_assignImpedanceValue, METH_VARARGS,"assign impedance of ith mode - assignImpedanceValue(i, real, imag)"},
+		{ "assignImpedance", assignImpedance, METH_VARARGS, "assign impedance of ith mode - assignImpedance(Z))"},
+		{ "setNumModes", LSpaceChargeCalc_setNumModes, METH_VARARGS, "set number of FFT modes used to calculate energy kick"},
+		{ "setUseGrad", LSpaceChargeCalc_setUseGrad, METH_VARARGS, "set whether to use gradient-based solver"},
 		{NULL}
   };
 

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,13 +46,12 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
-        int nFreq;
 
-		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins, &nFreq)){
-			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq) - constructor needs parameters.");
+		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
 		}
 
-		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq);
+		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins);
 
 		((LSpaceChargeCalc*) self->cpp_obj)->setPyWrapper((PyObject*) self);
 
@@ -93,7 +92,37 @@ extern "C"
 
 	}
 
+	static PyObject* LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args){
 
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+		int n = -1;
+        
+		if(!PyArg_ParseTuple(args,"i:arguments", &n)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setNumModes(n) - constructor needs parameters.");
+		}
+		cpp_LSpaceChargeCalc->setNumModes(n);
+
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	static PyObject* LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args){
+
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+		int setting = 0;
+        
+		if(!PyArg_ParseTuple(args,"i:arguments", &setting)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setUseGrad(setting) - constructor needs parameters.");
+		}
+		cpp_LSpaceChargeCalc->setUseGrad(setting);
+
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
 
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,12 +46,13 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
+        int nFreq;
 
-		if(!PyArg_ParseTuple(args,"ddiii:arguments",&b_a,&length,&nMacrosMin,&useSpaceCharge,&nBins)){
-			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
+		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins, &nFreq)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq) - constructor needs parameters.");
 		}
 
-		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins);
+		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq);
 
 		((LSpaceChargeCalc*) self->cpp_obj)->setPyWrapper((PyObject*) self);
 

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -120,6 +120,19 @@ extern "C"
         return Py_None;
     }
 
+    static PyObject *LSpaceChargeCalc_setSmoothGrad(PyObject *self, PyObject *args) {
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+        int smoothgrad;
+        if (!PyArg_ParseTuple(args, "i:arguments", &smoothgrad)) {
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setSmoothGrad(setting) - constructor needs parameters.");
+        }
+		cpp_LSpaceChargeCalc->setSmoothGrad(smoothgrad);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){
 
@@ -181,6 +194,7 @@ extern "C"
 		{ "assignImpedance", assignImpedance, METH_VARARGS, "assign impedance of ith mode - assignImpedance(Z))"},
 		{ "setNumModes", LSpaceChargeCalc_setNumModes, METH_VARARGS, "set number of FFT modes used to calculate energy kick"},
 		{ "setUseGrad", LSpaceChargeCalc_setUseGrad, METH_VARARGS, "set whether to use gradient-based solver"},
+		{ "setSmoothGrad", LSpaceChargeCalc_setSmoothGrad, METH_VARARGS, "set whether to use smooth gradients"},
 		{NULL}
   };
 


### PR DESCRIPTION
This PR gives the option to restrict the number of modes used in longitudinal space charge kicks. From Chao (3.7), the formula for the energy gain from longitudinal impedance $Z_{0}^{\parallel}(\omega)$ for particle at position $z$ is

$$
V(z) = -\int_{z}^{\infty}  \rho(z') W_0'(z - z') dz'.
$$

In the frequency domain (3.10):

$$
V(z) = -\frac{1}{2 \pi} \int_{-\infty}^{\infty}  e^{i \omega z / c} Z_0^{\parallel}(\omega) \tilde{\rho}(\omega) d\omega.
$$

From the FFT, the solver uses $N / 2$ frequencies/modes, where $N$ is the number of longitudinal bins.

https://github.com/PyORBIT-Collaboration/PyORBIT3/blob/e4ac4ce4b22163a71480a259730799b9f01e8913/src/spacecharge/LSpaceChargeCalc.cc#L211-L227

This PR lets the user restrict the number of modes used in the energy kick, acting as a low-pass filter.







