### PR TITLE
Gradient-based longitudinal space charge calculation

### DIFF
--- a/examples/SpaceCharge/sc1d/style.mplstyle
+++ b/examples/SpaceCharge/sc1d/style.mplstyle
@@ -1,0 +1,7 @@
+axes.linewidth: 1.25
+axes.titlesize: "medium"
+figure.constrained_layout.use: True
+savefig.dpi: 300
+savefig.format: "png"
+xtick.minor.visible: True
+ytick.minor.visible: True

--- a/examples/SpaceCharge/sc1d/test_lsc_gauss.py
+++ b/examples/SpaceCharge/sc1d/test_lsc_gauss.py
@@ -1,0 +1,89 @@
+import argparse
+import math
+
+import numpy as np
+
+from orbit.core.bunch import Bunch
+from orbit.core.spacecharge import LSpaceChargeCalc
+from orbit.core.spacecharge import SpaceChargeCalcSliceBySlice2D
+from orbit.bunch_utils import collect_bunch
+from orbit.utils.consts import mass_proton
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--b-a", type=float, default=3.0)
+parser.add_argument("--ring-length", type=float, default=250.0)
+parser.add_argument("--nmacros-min", type=int, default=0)
+parser.add_argument("--use_sc", type=int, default=1)
+parser.add_argument("--nbins", type=int, default=32)
+parser.add_argument("--bunch-radius", type=float, default=0.010)
+parser.add_argument("--bunch-length-rms", type=float, default=50.0)
+parser.add_argument("--nparts", type=int, default=10_000)
+parser.add_argument("--intensity", type=float, default=2e14)
+
+args = parser.parse_args()
+
+
+bunch = Bunch()
+bunch.mass(mass_proton)
+bunch.getSyncParticle().kinEnergy(1.0)
+
+rng = np.random.default_rng(0)
+r = args.bunch_radius * np.sqrt(rng.uniform(0.0, 1.0, size=args.nparts))
+t = rng.uniform(0.0, 2.0 * np.pi, size=args.nparts)
+x = r * np.cos(t)
+y = r * np.sin(t)
+xp = np.zeros_like(x)
+yp = np.zeros_like(y)
+z = rng.normal(scale=args.bunch_length_rms * 0.5, size=args.nparts)
+dE = np.zeros_like(z)
+
+coords = np.column_stack([x, xp, y, yp, z, dE])
+for i in range(args.nparts):
+    bunch.addParticle(*coords[i, :])
+
+bunch.macroSize(args.intensity / bunch.getSize())
+
+bunch_in = Bunch()
+bunch.copyBunchTo(bunch_in)
+
+
+# 1D
+
+sc_calc = LSpaceChargeCalc(
+    args.b_a, args.ring_length, args.nmacros_min, args.use_sc, args.nbins
+)
+if args.grad:
+    sc_calc.setUseGrad(args.grad)
+    sc_calc.setSmoothGrad(1)
+
+coords_in = collect_bunch(bunch)["coords"]
+print(np.max(coords_in[:, 5]))
+
+sc_calc.trackBunch(bunch)
+
+coords_out = collect_bunch(bunch)["coords"]
+print(np.max(coords_out[:, 5]))
+
+
+import matplotlib.pyplot as plt
+xmax = [0.5 * args.ring_length, 1.1 * np.max(coords_out[:, 5])]
+xmax = np.array(xmax)
+limits = list(zip(-xmax, xmax))
+
+fig, ax = plt.subplots()
+ax.hist2d(
+    coords_out[:, 4],
+    coords_out[:, 5],
+    bins=128,
+    range=limits,
+)
+# ax.scatter(
+#     coords_out[:, 4],
+#     coords_out[:, 5],
+#     ec="none",
+#     s=1.0,
+# )
+ax.set_xlim(limits[0])
+ax.set_ylim(limits[1])
+plt.show()

--- a/examples/SpaceCharge/sc1d/test_lsc_gauss.py
+++ b/examples/SpaceCharge/sc1d/test_lsc_gauss.py
@@ -1,14 +1,13 @@
 import argparse
-import math
 
 import numpy as np
 
 from orbit.core.bunch import Bunch
 from orbit.core.spacecharge import LSpaceChargeCalc
 from orbit.core.spacecharge import SpaceChargeCalcSliceBySlice2D
+from orbit.core.spacecharge import Boundary2D
 from orbit.bunch_utils import collect_bunch
 from orbit.utils.consts import mass_proton
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--b-a", type=float, default=3.0)
@@ -21,13 +20,17 @@ parser.add_argument("--bunch-length-rms", type=float, default=50.0)
 parser.add_argument("--nparts", type=int, default=10_000)
 parser.add_argument("--intensity", type=float, default=2e14)
 
+parser.add_argument("--grad", type=int, default=0)
+parser.add_argument("--modes", type=int, default=None)
 args = parser.parse_args()
 
-
+# Create bunch
 bunch = Bunch()
 bunch.mass(mass_proton)
 bunch.getSyncParticle().kinEnergy(1.0)
+bunch.macroSize(args.intensity / args.nparts)
 
+# Generate particles
 rng = np.random.default_rng(0)
 r = args.bunch_radius * np.sqrt(rng.uniform(0.0, 1.0, size=args.nparts))
 t = rng.uniform(0.0, 2.0 * np.pi, size=args.nparts)
@@ -42,48 +45,31 @@ coords = np.column_stack([x, xp, y, yp, z, dE])
 for i in range(args.nparts):
     bunch.addParticle(*coords[i, :])
 
-bunch.macroSize(args.intensity / bunch.getSize())
-
-bunch_in = Bunch()
-bunch.copyBunchTo(bunch_in)
-
-
-# 1D
-
+# Create space charge calculator
 sc_calc = LSpaceChargeCalc(
     args.b_a, args.ring_length, args.nmacros_min, args.use_sc, args.nbins
 )
+if args.modes:
+    sc_calc.setNumModes(args.modes)
 if args.grad:
     sc_calc.setUseGrad(args.grad)
     sc_calc.setSmoothGrad(1)
 
+# Track bunch
 coords_in = collect_bunch(bunch)["coords"]
-print(np.max(coords_in[:, 5]))
-
 sc_calc.trackBunch(bunch)
-
 coords_out = collect_bunch(bunch)["coords"]
-print(np.max(coords_out[:, 5]))
 
-
+# Plot position-energy distribution. The energy gain is proportional
+# to the longitudinal electric field.
 import matplotlib.pyplot as plt
+
 xmax = [0.5 * args.ring_length, 1.1 * np.max(coords_out[:, 5])]
 xmax = np.array(xmax)
 limits = list(zip(-xmax, xmax))
 
 fig, ax = plt.subplots()
-ax.hist2d(
-    coords_out[:, 4],
-    coords_out[:, 5],
-    bins=128,
-    range=limits,
-)
-# ax.scatter(
-#     coords_out[:, 4],
-#     coords_out[:, 5],
-#     ec="none",
-#     s=1.0,
-# )
+ax.scatter(coords_out[:, 4], coords_out[:, 5], ec="none", s=1.0, c="black")
 ax.set_xlim(limits[0])
 ax.set_ylim(limits[1])
 plt.show()

--- a/examples/SpaceCharge/sc1d/test_lsc_gauss.py
+++ b/examples/SpaceCharge/sc1d/test_lsc_gauss.py
@@ -27,6 +27,7 @@ parser.add_argument("--nparts", type=int, default=10_000)
 parser.add_argument("--intensity", type=float, default=2e14)
 
 parser.add_argument("--grad", type=int, default=0)
+parser.add_argument("--grad-smooth", type=int, default=1)
 parser.add_argument("--modes", type=int, default=None)
 args = parser.parse_args()
 
@@ -66,7 +67,7 @@ if args.modes:
     sc_calc.setNumModes(args.modes)
 if args.grad:
     sc_calc.setUseGrad(args.grad)
-    sc_calc.setSmoothGrad(1)
+    sc_calc.setSmoothGrad(args.grad_smooth)
 
 # Track bunch
 coords_in = collect_bunch(bunch)["coords"]
@@ -99,10 +100,14 @@ xmax = np.array(xmax)
 limits = list(zip(-xmax, xmax))
 
 fig, ax = plt.subplots()
-ax.scatter(coords_out[:, 4], 1000.0 * coords_out[:, 5], ec="none", s=1.0, c="black")
 ax.plot(z_pred, 1000.0 * dE_pred, color="red", zorder=0)
+ax.scatter(coords_out[:, 4], 1000.0 * coords_out[:, 5], ec="none", s=1.0, c="black")
 ax.set_xlim(limits[0])
 ax.set_ylim(limits[1])
+ax.set_ylim(
+    -1000.0 * 1.2 * np.max(np.abs(dE_pred)),
+    +1000.0 * 1.2 * np.max(np.abs(dE_pred)),
+)
 ax.set_xlabel("z [m]")
 ax.set_ylabel("dE [MeV]")
 plt.savefig(os.path.join(output_dir, "fig_lsc_gauss.png"), dpi=300)

--- a/examples/SpaceCharge/sc1d/test_lsc_gauss.py
+++ b/examples/SpaceCharge/sc1d/test_lsc_gauss.py
@@ -1,6 +1,8 @@
 import argparse
+import os
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 from orbit.core.bunch import Bunch
 from orbit.core.spacecharge import LSpaceChargeCalc
@@ -9,7 +11,11 @@ from orbit.core.spacecharge import Boundary2D
 from orbit.bunch_utils import collect_bunch
 from orbit.utils.consts import mass_proton
 
+plt.style.use("style.mplstyle")
+
+
 parser = argparse.ArgumentParser()
+parser.add_argument("--kin_energy", type=float, default=1.0)
 parser.add_argument("--b-a", type=float, default=3.0)
 parser.add_argument("--ring-length", type=float, default=250.0)
 parser.add_argument("--nmacros-min", type=int, default=0)
@@ -24,11 +30,18 @@ parser.add_argument("--grad", type=int, default=0)
 parser.add_argument("--modes", type=int, default=None)
 args = parser.parse_args()
 
+
+# Paths
+output_dir = "outputs"
+os.makedirs(output_dir, exist_ok=True)
+
 # Create bunch
 bunch = Bunch()
 bunch.mass(mass_proton)
-bunch.getSyncParticle().kinEnergy(1.0)
 bunch.macroSize(args.intensity / args.nparts)
+
+sync_part = bunch.getSyncParticle()
+sync_part.kinEnergy(args.kin_energy)
 
 # Generate particles
 rng = np.random.default_rng(0)
@@ -60,16 +73,37 @@ coords_in = collect_bunch(bunch)["coords"]
 sc_calc.trackBunch(bunch)
 coords_out = collect_bunch(bunch)["coords"]
 
+# Analytic result (assume zero mean Gaussian)
+g = 1.0 + 2.0 * np.log(args.b_a)
+factor = (
+    args.ring_length
+    * g
+    * bunch.classicalRadius()
+    * bunch.mass()
+    / (sync_part.gamma() ** 2)
+)
+z = args.ring_length * np.linspace(-0.5, 0.5, 1000)
+sigma = args.bunch_length_rms * 0.5
+density = np.sqrt(1.0 / (2.0 * np.pi * sigma**2)) * np.exp(-0.5 * (z / sigma) ** 2)
+density *= args.intensity
+density_grad = -(z / sigma**2) * density
+energy_kick = -factor * density_grad
+
+z_pred = z
+dE_pred = energy_kick
+
 # Plot position-energy distribution. The energy gain is proportional
 # to the longitudinal electric field.
-import matplotlib.pyplot as plt
-
-xmax = [0.5 * args.ring_length, 1.1 * np.max(coords_out[:, 5])]
+xmax = [0.5 * args.ring_length, 1.1 * 1000.0 * np.max(coords_out[:, 5])]
 xmax = np.array(xmax)
 limits = list(zip(-xmax, xmax))
 
 fig, ax = plt.subplots()
-ax.scatter(coords_out[:, 4], coords_out[:, 5], ec="none", s=1.0, c="black")
+ax.scatter(coords_out[:, 4], 1000.0 * coords_out[:, 5], ec="none", s=1.0, c="black")
+ax.plot(z_pred, 1000.0 * dE_pred, color="red", zorder=0)
 ax.set_xlim(limits[0])
 ax.set_ylim(limits[1])
+ax.set_xlabel("z [m]")
+ax.set_ylabel("dE [MeV]")
+plt.savefig(os.path.join(output_dir, "fig_lsc_gauss.png"), dpi=300)
 plt.show()

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -6,33 +6,25 @@ import sys
 import os
 import math
 
-# import the function that finalizes the execution
-from orbit.utils import orbitFinalize
-
-# import physical constants
-from orbit.utils import consts
-
-# import general accelerator elements and lattice
-from orbit.lattice import AccLattice, AccNode, AccActionsContainer, AccNodeBunchTracker
-
-# import teapot drift class
-from orbit.teapot import DriftTEAPOT
-
-# import longitudinal space charge package
+from orbit.core.bunch import Bunch
 from orbit.core.spacecharge import LSpaceChargeCalc
-
-# -----------------------------------------------------------------------------
-# Node for impedance as function of node number
-# -----------------------------------------------------------------------------
+from orbit.lattice import AccLattice
+from orbit.lattice import AccNode
+from orbit.lattice import AccActionsContainer
+from orbit.lattice import AccNodeBunchTracker
+from orbit.utils import consts
+from orbit.utils import orbitFinalize
+from orbit.teapot import DriftTEAPOT
 
 
 class SC1D_AccNode(DriftTEAPOT):
-    def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, name="long sc node"):
+    """Longitudinal space charge node."""
+    def __init__(self, b_a: float, phase_length: float, nmacros_min: float, use_sc: float, nbins: float, nfreq: int = -1, name="long sc node"):
         """
         Constructor. Creates the SC1D-teapot element.
         """
         DriftTEAPOT.__init__(self, name)
-        self.lspacecharge = LSpaceChargeCalc(b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins)
+        self.lspacecharge = LSpaceChargeCalc(b_a, phase_length, nmacros_min, use_sc, nbins, nfreq)
         self.setType("long sc node")
         self.setLength(0.0)
 
@@ -51,18 +43,14 @@ class SC1D_AccNode(DriftTEAPOT):
         """
         length = self.getLength(self.getActivePartIndex())
         bunch = paramsDict["bunch"]
-        self.lspacecharge.trackBunch(bunch)  # track method goes here
+        self.lspacecharge.trackBunch(bunch)
 
     def assignImpedance(self, py_cmplx_arr):
         self.lspacecharge.assignImpedance(py_cmplx_arr)
 
 
-# -----------------------------------------------------------------------------
-# Node for impedance as function of frequency
-# -----------------------------------------------------------------------------
-
-
 class FreqDep_SC1D_AccNode(DriftTEAPOT):
+    """Longitudinal space charge node (frequency-dependent)."""
     def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, bunch, impeDict, name="freq. dep. long sc node"):
         """
         Constructor. Creates the FreqDep_SC1D-teapot element.
@@ -121,12 +109,8 @@ class FreqDep_SC1D_AccNode(DriftTEAPOT):
         self.lspacecharge.trackBunch(bunch)
 
 
-# -----------------------------------------------------------------------------
-# Node for impedance as function of beta and frequency
-# -----------------------------------------------------------------------------
-
-
 class BetFreqDep_SC1D_AccNode(DriftTEAPOT):
+    """Longitudinal space charge node (frequency- and velocity-dependent)."""
     def __init__(self, b_a, phaseLength, nMacrosMin, useSpaceCharge, nBins, bunch, impeDict, name="freq. dep. long sc node"):
         """
         Constructor. Creates the BetFreqDep_SC1D-teapot element.

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -27,8 +27,6 @@ class SC1D_AccNode(DriftTEAPOT):
         nmacros_min: float,
         use_sc: float,
         nbins: float,
-        nmodes: int = None,
-        use_grad: bool = False,
         name="long sc node",
     ) -> None:
         """
@@ -36,8 +34,6 @@ class SC1D_AccNode(DriftTEAPOT):
         """
         DriftTEAPOT.__init__(self, name)
         self.lspacecharge = LSpaceChargeCalc(b_a, phase_length, nmacros_min, use_sc, nbins)
-        self.setNumModes(nmodes)
-        # self.setUseGrad(use_grad)
         self.setType("long sc node")
         self.setLength(0.0)
 

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -37,9 +37,13 @@ class SC1D_AccNode(DriftTEAPOT):
         self.setType("long sc node")
         self.setLength(0.0)
 
-    def setUseGrad(self, use_grad: bool) -> None:
+    def setUseGrad(self, setting: bool) -> None:
         """Sets whether to use gradient-based solver instead of impedance solver."""
-        self.lspacecharge.setUseGrad(int(use_grad))
+        self.lspacecharge.setUseGrad(int(setting))
+
+    def setSmoothGrad(self, setting: bool) -> None:
+        """Sets whether to use smoothed gradient."""
+        self.lspacecharge.setSmoothGrad(int(setting))
 
     def setNumModes(self, n: int) -> None:
         """Sets number of FFT modes used to calculate energy kick."""

--- a/py/orbit/space_charge/sc1d/sc1DNode.py
+++ b/py/orbit/space_charge/sc1d/sc1DNode.py
@@ -54,7 +54,6 @@ class SC1D_AccNode(DriftTEAPOT):
         The SC1D-teapot class implementation of the
         AccNodeBunchTracker class trackBunch(probe) method.
         """
-        length = self.getLength(self.getActivePartIndex())
         self.lspacecharge.trackBunch(bunch)  # track method goes here
 
     def track(self, params_dict: dict) -> None:
@@ -62,7 +61,6 @@ class SC1D_AccNode(DriftTEAPOT):
         The SC1D-teapot class implementation of the
         AccNodeBunchTracker class track(probe) method.
         """
-        length = self.getLength(self.getActivePartIndex())
         bunch = params_dict["bunch"]
         self.lspacecharge.trackBunch(bunch)
 

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -106,7 +106,7 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
     if (nPartsGlobal < nMacrosMin)
         return;
 
-    // Bin the particles
+    // Bin the particles.
     double zmin, zmax;
     double realPart, imagPart;
 
@@ -119,101 +119,70 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
     zGrid->binBunchSmoothedByParticle(bunch);
     zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
 
-    if (useGrad == 0) {  // Impedance-based solver
+    // FFT the beam density.
+    for (int i = 0; i < nBins; i++) {
+        _in[i][0] = zGrid->getValueOnGrid(i);
+        _in[i][1] = 0.;
+    }
 
-        // FFT the beam density
-        for (int i = 0; i < nBins; i++) {
-            _in[i][0] = zGrid->getValueOnGrid(i);
-            _in[i][1] = 0.;
-        }
+    fftw_execute(_plan);
 
-        fftw_execute(_plan);
+    // Find the magnitude and phase
+    _fftmagnitude[0] = _out[0][0] / (double)nBins;
+    _fftphase[0] = 0.;
 
-        // Find the magnitude and phase
-        _fftmagnitude[0] = _out[0][0] / (double)nBins;
-        _fftphase[0] = 0.;
+    for (int n = 1; n < nBins / 2; n++) {
+        realPart = _out[n][0] / ((double)nBins);
+        imagPart = _out[n][1] / ((double)nBins);
+        _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
+        _fftphase[n] = atan2(imagPart, realPart);
+    }
 
-        for (int n = 1; n < nBins / 2; n++) {
-            realPart = _out[n][0] / ((double)nBins);
-            imagPart = _out[n][1] / ((double)nBins);
-            _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
-            _fftphase[n] = atan2(imagPart, realPart);
-        }
+    // Space charge contribution to impedance.
+    SyncPart *sp = bunch->getSyncPart();
 
-        // Space charge contribution to impedance
-        SyncPart *sp = bunch->getSyncPart();
+    // Set zero if useSpaceCharge = 0.
+    double zSpaceCharge_n = 0.;
 
-        // Set zero if useSpaceCharge = 0
-        double zSpaceCharge_n = 0.;
+    // Otherwise, set positive since space charge is capacitive (Chao convention).
+    if (useSpaceCharge != 0) {
+        double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
+        double _z_0 = OrbitConst::c * mu_0;
 
-        // Otherwise, set positive since space charge is capacitive (Chao convention)
-        if (useSpaceCharge != 0) {
-            double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
-            double _z_0 = OrbitConst::c * mu_0;
+        zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
+                         (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
+    }
 
-            zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
-                             (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
-        }
+    for (int n = 1; n < nBins / 2; n++) {
+        realPart = std::real(_zImped_n[n]);
+        imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
+        _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
+        _chi[n] = atan2(imagPart, realPart);
+    }
 
-        for (int n = 1; n < nBins / 2; n++) {
-            realPart = std::real(_zImped_n[n]);
-            imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
-            _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
-            _chi[n] = atan2(imagPart, realPart);
-        }
+    // Convert charge to current for a single macroparticle per unit bin length.
+    double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
 
-        // Convert charge to current for a single macroparticle per unit bin length
-        double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
+    // Calculate and add the kick to macroparticles.
+    double kick, angle, position;
 
-        // Calculate and add the kick to macroparticles
-        double kick, angle, position;
+    // Convert particle longitudinal coordinate to phi.
+    double philocal;
+    double z;
+    double **coords = bunch->coordArr();
+    for (int j = 0; j < bunch->getSize(); j++) {
+        z = bunch->z(j);
+        philocal = (z / length) * 2 * OrbitConst::PI;
 
-        // Convert particle longitudinal coordinate to phi
-        double philocal;
-        double z;
-        double **coords = bunch->coordArr();
-        for (int j = 0; j < bunch->getSize(); j++) {
-            z = bunch->z(j);
-            philocal = (z / length) * 2 * OrbitConst::PI;
+        // Handle cases where the longitudinal coordinate is
+        // outside of the user-specified length
+        if (philocal < -OrbitConst::PI)
+            philocal += 2 * OrbitConst::PI;
+        if (philocal > OrbitConst::PI)
+            philocal -= 2 * OrbitConst::PI;
 
-            // Handle cases where the longitudinal coordinate is
-            // outside of the user-specified length
-            if (philocal < -OrbitConst::PI)
-                philocal += 2 * OrbitConst::PI;
-            if (philocal > OrbitConst::PI)
-                philocal -= 2 * OrbitConst::PI;
-
-            double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-            coords[j][5] += dE;
-        }
-    } 
-    else {  // Gradient-based solver
-        double pi = OrbitConst::PI;
-        double c = OrbitConst::c;
-        double mu0 = OrbitConst::permeability;
-        double eps0 = 1.0 / (mu0 * c * c);
-        double g = (1.0 + 2.0 * log(b_a));
-        double q = bunch->getCharge();
-
-        SyncPart *sp = bunch->getSyncPart();
-        double beta = sp->getBeta();
-        double gamma = sp->getGamma();
-
-        double ez_factor = g * q / (4.0 * pi * eps0 * gamma * gamma);
-        double kick_factor = length * bunch->getClassicalRadius() * bunch->getMass();
-
-        double z, ez, density_gradient;
-        for (int i = 0, n = bunch->getSize(); i < n; i++) {
-            z = bunch->z(i) * gamma;
-            if (smooth > 0) {
-                zGrid->calcGradientSmoothed(z, density_gradient);
-            }
-            else {
-                zGrid->calcGradient(z, density_gradient);
-            }
-            ez = density_gradient * ez_factor;
-            bunch->dE(i) -= ez * kick_factor;
-        }
+        double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
+        coords[j][5] += dE;
     }
 }
 

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -184,9 +184,38 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
         }
     } 
     else {
-        std::cout << "Gradient-based solver is not implemented.";
+        double pi = OrbitConst::PI;
+        double c = OrbitConst::c;
+        double mu0 = OrbitConst::permeability;
+        double eps0 = 1.0 / (mu0 * c * c);
+        double g = (1.0 + 2.0 * log(b_a));
+        double q = bunch->getCharge();
+
+        SyncPart *sp = bunch->getSyncPart();
+        double beta = sp->getBeta();
+        double gamma = sp->getGamma();
+        double ez_factor = g * q / (4.0 * pi * eps0 * gamma * gamma);
+
+        double kick_factor = length * bunch->getClassicalRadius() * bunch->getMass();
+
+        int smooth = 1;
+
+        double z, ez, density_gradient;
+        for (int i = 0, n = bunch->getSize(); i < n; i++) {
+            z = bunch->z(i) * gamma;
+            if (smooth > 0) {
+                zGrid->calcGradientSmoothed(z, density_gradient);
+            }
+            else {
+                zGrid->calcGradient(z, density_gradient);
+            }
+            ez = density_gradient * ez_factor;
+            bunch->dE(i) -= ez * kick_factor;
+        }
     }
 }
+
+
 
 ///////////////////////////////////////////////////////////////////////////
 //

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -11,194 +11,182 @@
 //
 /////////////////////////////////////////////////////////////////////////////
 
-#include "Grid1D.hh"
-#include "BufferStore.hh"
 #include "LSpaceChargeCalc.hh"
+#include "BufferStore.hh"
+#include "Grid1D.hh"
 #include "OrbitConst.hh"
+#include <cfloat>
+#include <cmath>
 #include <complex>
 #include <iostream>
-#include <cmath>
-#include <cfloat>
-#include <complex>
 
-//FFTW library header
+// FFTW library header
 #include "fftw3.h"
 
 using namespace OrbitUtils;
 
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in) : CppPyWrapper(NULL) {
+    b_a = b_a_in;
+    length = length_in;
+    nMacrosMin = nMacrosMin_in;
+    useSpaceCharge = useSpaceCharge_in;
+    nBins = nBins_in;
+    zGrid = new Grid1D(nBins, length);
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
-{
-  b_a            = b_a_in;
-  length         = length_in;
-  nMacrosMin     = nMacrosMin_in;
-  useSpaceCharge = useSpaceCharge_in;
-  nBins          = nBins_in;
-  zGrid          = new Grid1D(nBins, length);
-    
-  nModes = nBins / 2;
-  useGrad = 0;
+    nModes = nBins / 2;
+    useGrad = 0;
 
-  _fftmagnitude  = new double[nBins / 2];
-  _fftphase      = new double[nBins / 2];
-  _z             = new double[nBins / 2];
-  _chi           = new double[nBins / 2];
-  //---------------------------
-  // _zImped_n size was increased by 1 to avoid crash due to
-  // assignment in LSpaceChargeCalc::assignImpedanceValue(...)
-  // to _zImped_n[n + 1] element. This should be resolved later.
-  //----------------------------
-  _zImped_n      = new std::complex<double>[nBins / 2 + 1];
+    _fftmagnitude = new double[nBins / 2];
+    _fftphase = new double[nBins / 2];
+    _z = new double[nBins / 2];
+    _chi = new double[nBins / 2];
+    //---------------------------
+    // _zImped_n size was increased by 1 to avoid crash due to
+    // assignment in LSpaceChargeCalc::assignImpedanceValue(...)
+    // to _zImped_n[n + 1] element. This should be resolved later.
+    //----------------------------
+    _zImped_n = new std::complex<double>[nBins / 2 + 1];
 
-  for(int n = 0; n < nBins / 2; n++)
-  {
-    _fftmagnitude[n] = 0.0;
-    _fftphase[n]     = 0.0;
-    _z[n]            = 0.0;
-    _chi[n]          = 0.0;
-    _zImped_n[n] = std::complex<double>(0.0, 0.0);
-  }
+    for (int n = 0; n < nBins / 2; n++) {
+        _fftmagnitude[n] = 0.0;
+        _fftphase[n] = 0.0;
+        _z[n] = 0.0;
+        _chi[n] = 0.0;
+        _zImped_n[n] = std::complex<double>(0.0, 0.0);
+    }
 
-  _in   = (fftw_complex *) fftw_malloc(nBins * sizeof(fftw_complex));
-  _out  = (fftw_complex *) fftw_malloc(nBins * sizeof(fftw_complex));
-  _plan = fftw_plan_dft_1d(nBins, _in,  _out, FFTW_FORWARD, FFTW_ESTIMATE);
+    _in = (fftw_complex *)fftw_malloc(nBins * sizeof(fftw_complex));
+    _out = (fftw_complex *)fftw_malloc(nBins * sizeof(fftw_complex));
+    _plan = fftw_plan_dft_1d(nBins, _in, _out, FFTW_FORWARD, FFTW_ESTIMATE);
 }
 
-
-LSpaceChargeCalc::~LSpaceChargeCalc()
-{
-  if(zGrid->getPyWrapper() != NULL)
-  {
-    Py_DECREF(zGrid->getPyWrapper());
-  }
-  else
-  {
-    delete zGrid;
-  }
-  delete[] _fftmagnitude;
-  delete[] _fftphase;
-  delete[] _z;
-  delete[] _chi;
-  delete[] _zImped_n;
-  fftw_free(_in);
-  fftw_free(_out);
-  fftw_destroy_plan(_plan);
+LSpaceChargeCalc::~LSpaceChargeCalc() {
+    if (zGrid->getPyWrapper() != NULL) {
+        Py_DECREF(zGrid->getPyWrapper());
+    } else {
+        delete zGrid;
+    }
+    delete[] _fftmagnitude;
+    delete[] _fftphase;
+    delete[] _z;
+    delete[] _chi;
+    delete[] _zImped_n;
+    fftw_free(_in);
+    fftw_free(_out);
+    fftw_destroy_plan(_plan);
 }
-
 
 void LSpaceChargeCalc::setNumModes(int n) {
-  nModes = n;
-  int nModesMax = nBins / 2;
-    
-  if (nModes > nModesMax) {
-    nModes = nModesMax;
-  }
-  if (nModes < 0) {
-    nModes = nModesMax;
-  }
-}
+    nModes = n;
+    int nModesMax = nBins / 2;
 
+    if (nModes > nModesMax) {
+        nModes = nModesMax;
+    }
+    if (nModes < 0) {
+        nModes = nModesMax;
+    }
+}
 
 void LSpaceChargeCalc::setUseGrad(int setting) {
     useGrad = setting;
 }
 
-
-void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag)
-{
-  _zImped_n[n + 1] = std::complex<double>(real, imag);
+void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag) {
+    _zImped_n[n + 1] = std::complex<double>(real, imag);
 }
 
+void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
+    int nPartsGlobal = bunch->getSizeGlobal();
+    if (nPartsGlobal < nMacrosMin)
+        return;
 
-void LSpaceChargeCalc::trackBunch(Bunch* bunch)
-{
-  int nPartsGlobal = bunch->getSizeGlobal();
-  if(nPartsGlobal < nMacrosMin) return;
+    // Bin the particles
+    double zmin, zmax;
+    double realPart, imagPart;
 
-  // Bin the particles
-  double zmin, zmax;
-  double realPart, imagPart;
+    bunchExtremaCalc->getExtremaZ(bunch, zmin, zmax);
+    double zextra = (length - (zmax - zmin)) / 2.0;
+    zmax += zextra;
+    zmin = zmax - length;
+    zGrid->setGridZ(zmin, zmax);
+    zGrid->setZero();
+    zGrid->binBunchSmoothedByParticle(bunch);
+    zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
 
-  bunchExtremaCalc->getExtremaZ(bunch, zmin, zmax);
-  double zextra = (length - (zmax - zmin)) / 2.0;
-  zmax += zextra;
-  zmin  = zmax - length;
-  zGrid->setGridZ(zmin, zmax);
-  zGrid->setZero();
-  zGrid->binBunchSmoothedByParticle(bunch);
-  zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
+    if (useGrad == 0) {
 
-  // FFT the beam density
-  for(int i = 0; i < nBins; i++)
-  {
-    _in[i][0] = zGrid->getValueOnGrid(i);
-    _in[i][1] = 0.;
-  }
+        // FFT the beam density
+        for (int i = 0; i < nBins; i++) {
+            _in[i][0] = zGrid->getValueOnGrid(i);
+            _in[i][1] = 0.;
+        }
 
-  fftw_execute(_plan);
+        fftw_execute(_plan);
 
-  // Find the magnitude and phase
-  _fftmagnitude[0] = _out[0][0]/(double)nBins;
-  _fftphase[0] = 0.;
+        // Find the magnitude and phase
+        _fftmagnitude[0] = _out[0][0] / (double)nBins;
+        _fftphase[0] = 0.;
 
-  for(int n = 1; n < nBins / 2; n++)
-  {
-    realPart = _out[n][0]/((double)nBins);
-    imagPart = _out[n][1]/((double)nBins);
-    _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
-    _fftphase[n] = atan2(imagPart,realPart);
-  }
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = _out[n][0] / ((double)nBins);
+            imagPart = _out[n][1] / ((double)nBins);
+            _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
+            _fftphase[n] = atan2(imagPart, realPart);
+        }
 
-  // Space charge contribution to impedance
-  SyncPart* sp = bunch->getSyncPart();
+        // Space charge contribution to impedance
+        SyncPart *sp = bunch->getSyncPart();
 
-  // Set zero if useSpaceCharge = 0
-  double zSpaceCharge_n = 0.;
+        // Set zero if useSpaceCharge = 0
+        double zSpaceCharge_n = 0.;
 
-  // Otherwise, set positive since space charge is capacitive (Chao convention)
-  if(useSpaceCharge != 0)
-  {
-    double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
-    double _z_0 = OrbitConst::c * mu_0;
+        // Otherwise, set positive since space charge is capacitive (Chao convention)
+        if (useSpaceCharge != 0) {
+            double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
+            double _z_0 = OrbitConst::c * mu_0;
 
-    zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
-                     (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
-  }
+            zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
+                             (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
+        }
 
-  for(int n = 1; n < nBins / 2; n++)
-  {
-    realPart = std::real(_zImped_n[n]);
-    imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
-    _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
-    _chi[n] = atan2(imagPart, realPart);
-  }
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = std::real(_zImped_n[n]);
+            imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
+            _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
+            _chi[n] = atan2(imagPart, realPart);
+        }
 
-  // Convert charge to current for a single macroparticle per unit bin length
-  double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
+        // Convert charge to current for a single macroparticle per unit bin length
+        double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
 
-  // Calculate and add the kick to macroparticles
-  double kick, angle, position;
+        // Calculate and add the kick to macroparticles
+        double kick, angle, position;
 
-  // Convert particle longitudinal coordinate to phi
+        // Convert particle longitudinal coordinate to phi
 
-  double philocal;
-  double z;
-  double** coords = bunch->coordArr();
-  for (int j = 0; j < bunch->getSize(); j++)
-  {
-    z = bunch->z(j);
-    philocal = (z / length) * 2 * OrbitConst::PI;
+        double philocal;
+        double z;
+        double **coords = bunch->coordArr();
+        for (int j = 0; j < bunch->getSize(); j++) {
+            z = bunch->z(j);
+            philocal = (z / length) * 2 * OrbitConst::PI;
 
-  // Handle cases where the longitudinal coordinate is
-  // outside of the user-specified length
-  if(philocal < -OrbitConst::PI) philocal += 2 * OrbitConst::PI;
-  if(philocal >  OrbitConst::PI) philocal -= 2 * OrbitConst::PI;
+            // Handle cases where the longitudinal coordinate is
+            // outside of the user-specified length
+            if (philocal < -OrbitConst::PI)
+                philocal += 2 * OrbitConst::PI;
+            if (philocal > OrbitConst::PI)
+                philocal -= 2 * OrbitConst::PI;
 
-  double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-  coords[j][5] += dE;
-  }
+            double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
+            coords[j][5] += dE;
+        }
+    } 
+    else {
+        std::cout << "Gradient-based solver is not implemented.";
+    }
 }
-
 
 ///////////////////////////////////////////////////////////////////////////
 //
@@ -217,20 +205,18 @@ void LSpaceChargeCalc::trackBunch(Bunch* bunch)
 //
 ///////////////////////////////////////////////////////////////////////////
 
-double LSpaceChargeCalc::_kick(double angle)
-{
-  // n=0 term has no impact (constant in phi)
-  // f(phi) = _FFTMagnitude(1) + sum (n = 2 -> N / 2) of
-  //          [2 * _FFTMagnitude(i) * cos(phi * (n - 1) +
-  //          _FFTPhase(n) + _chi(n))]
+double LSpaceChargeCalc::_kick(double angle) {
+    // n=0 term has no impact (constant in phi)
+    // f(phi) = _FFTMagnitude(1) + sum (n = 2 -> N / 2) of
+    //          [2 * _FFTMagnitude(i) * cos(phi * (n - 1) +
+    //          _FFTPhase(n) + _chi(n))]
 
-  double kick = 0.;
-  double cosArg;
+    double kick = 0.;
+    double cosArg;
 
-  for(int n = 1; n < nModes; n++)
-  {
-    cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
-    kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);
-  }
-  return kick;
+    for (int n = 1; n < nModes; n++) {
+        cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
+        kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);
+    }
+    return kick;
 }

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -27,7 +27,7 @@
 using namespace OrbitUtils;
 
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in, int nFreq_in): CppPyWrapper(NULL)
 {
   b_a            = b_a_in;
   length         = length_in;
@@ -35,6 +35,7 @@ LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosM
   useSpaceCharge = useSpaceCharge_in;
   nBins          = nBins_in;
   zGrid          = new Grid1D(nBins, length);
+  nFreq = nFreq_in;
 
   _fftmagnitude  = new double[nBins / 2];
   _fftphase      = new double[nBins / 2];

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -193,7 +193,8 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
         zGrid->multiply(bunch->getCharge() * bunch->getMacroSize() / bin_size);
         
         // Calculate constant factor for energy kick.
-        double factor = length * bunch->getClassicalRadius() * bunch->getMass() / (sp->getGamma() * sp->getGamma());
+        double g = 1.0 + 2.0 * log(b_a);
+        double factor = length * g * bunch->getClassicalRadius() * bunch->getMass() / (sp->getGamma() * sp->getGamma());
 
         double **coords = bunch->coordArr();
         double z;

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -27,7 +27,7 @@
 using namespace OrbitUtils;
 
 
-LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in, int nFreq_in): CppPyWrapper(NULL)
+LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int nBins_in): CppPyWrapper(NULL)
 {
   b_a            = b_a_in;
   length         = length_in;
@@ -36,13 +36,8 @@ LSpaceChargeCalc::LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosM
   nBins          = nBins_in;
   zGrid          = new Grid1D(nBins, length);
     
-  nFreq = nFreq_in;
-  if (nFreq > (nBins / 2)) {
-    nFreq = nBins / 2;
-  }
-  if (nFreq < 0) {
-    nFreq = nBins / 2;
-  }
+  nModes = nBins / 2;
+  useGrad = 0;
 
   _fftmagnitude  = new double[nBins / 2];
   _fftphase      = new double[nBins / 2];
@@ -88,6 +83,24 @@ LSpaceChargeCalc::~LSpaceChargeCalc()
   fftw_free(_in);
   fftw_free(_out);
   fftw_destroy_plan(_plan);
+}
+
+
+void LSpaceChargeCalc::setNumModes(int n) {
+  nModes = n;
+  int nModesMax = nBins / 2;
+    
+  if (nModes > nModesMax) {
+    nModes = nModesMax;
+  }
+  if (nModes < 0) {
+    nModes = nModesMax;
+  }
+}
+
+
+void LSpaceChargeCalc::setUseGrad(int setting) {
+    useGrad = setting;
 }
 
 
@@ -214,7 +227,7 @@ double LSpaceChargeCalc::_kick(double angle)
   double kick = 0.;
   double cosArg;
 
-  for(int n = 1; n < nFreq; n++)
+  for(int n = 1; n < nModes; n++)
   {
     cosArg = n * (angle + OrbitConst::PI) + _fftphase[n] + _chi[n];
     kick += 2 * _fftmagnitude[n] * _z[n] * cos(cosArg);

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -119,71 +119,110 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
     zGrid->binBunchSmoothedByParticle(bunch);
     zGrid->synchronizeMPI(bunch->getMPI_Comm_Local());
 
-    // FFT the beam density.
-    for (int i = 0; i < nBins; i++) {
-        _in[i][0] = zGrid->getValueOnGrid(i);
-        _in[i][1] = 0.;
+    if (useGrad == 0) {
+
+        // FFT the beam density.
+        for (int i = 0; i < nBins; i++) {
+            _in[i][0] = zGrid->getValueOnGrid(i);
+            _in[i][1] = 0.;
+        }
+
+        fftw_execute(_plan);
+
+        // Find the magnitude and phase
+        _fftmagnitude[0] = _out[0][0] / (double)nBins;
+        _fftphase[0] = 0.;
+
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = _out[n][0] / ((double)nBins);
+            imagPart = _out[n][1] / ((double)nBins);
+            _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
+            _fftphase[n] = atan2(imagPart, realPart);
+        }
+
+        // Space charge contribution to impedance.
+        SyncPart *sp = bunch->getSyncPart();
+
+        // Set zero if useSpaceCharge = 0.
+        double zSpaceCharge_n = 0.;
+
+        // Otherwise, set positive since space charge is capacitive (Chao convention).
+        if (useSpaceCharge != 0) {
+            double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
+            double _z_0 = OrbitConst::c * mu_0;
+
+            zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
+                            (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
+        }
+
+        for (int n = 1; n < nBins / 2; n++) {
+            realPart = std::real(_zImped_n[n]);
+            imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
+            _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
+            _chi[n] = atan2(imagPart, realPart);
+        }
+
+        // Convert charge to current for a single macroparticle per unit bin length.
+        double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
+
+        // Calculate and add the kick to macroparticles.
+        double kick, angle, position;
+
+        // Convert particle longitudinal coordinate to phi.
+        double philocal;
+        double z;
+        double **coords = bunch->coordArr();
+        for (int j = 0; j < bunch->getSize(); j++) {
+            z = bunch->z(j);
+            philocal = (z / length) * 2 * OrbitConst::PI;
+
+            // Handle cases where the longitudinal coordinate is
+            // outside of the user-specified length
+            if (philocal < -OrbitConst::PI)
+                philocal += 2 * OrbitConst::PI;
+            if (philocal > OrbitConst::PI)
+                philocal -= 2 * OrbitConst::PI;
+
+            double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
+            if (j == 0) {
+                std::cout << "debug j= " << j << " dE = " << dE << "\n"; 
+            }
+            coords[j][5] += dE;
+        }
+    }
+    else {
+        double z;
+        double **coords = bunch->coordArr();
+
+        SyncPart *sp = bunch->getSyncPart();
+        double gamma = sp->getGamma();
+        double factor = length * bunch->getClassicalRadius() * bunch->getMass() / (gamma * gamma);
+
+        double density_gradient;
+        double dE;
+        for (int j = 0; j < bunch->getSize(); j++) {
+            z = bunch->z(j);
+            // z = bunch->z(j) * gamma;  // rest frame
+
+            // Handle cases where the longitudinal coordinate is
+            // outside of the user-specified length
+            // ...
+
+            if (smooth > 0) {
+                zGrid->calcGradientSmoothed(z, density_gradient);
+            }
+            else {
+                zGrid->calcGradient(z, density_gradient);
+            }
+            double dE = -factor * density_gradient;
+            dE = dE * 1e9; // ?
+            if (j == 0) {
+                std::cout << "debug j= " << j << " dE = " << dE << "\n"; 
+            }
+            coords[j][5] += dE;
+        }
     }
 
-    fftw_execute(_plan);
-
-    // Find the magnitude and phase
-    _fftmagnitude[0] = _out[0][0] / (double)nBins;
-    _fftphase[0] = 0.;
-
-    for (int n = 1; n < nBins / 2; n++) {
-        realPart = _out[n][0] / ((double)nBins);
-        imagPart = _out[n][1] / ((double)nBins);
-        _fftmagnitude[n] = sqrt(realPart * realPart + imagPart * imagPart);
-        _fftphase[n] = atan2(imagPart, realPart);
-    }
-
-    // Space charge contribution to impedance.
-    SyncPart *sp = bunch->getSyncPart();
-
-    // Set zero if useSpaceCharge = 0.
-    double zSpaceCharge_n = 0.;
-
-    // Otherwise, set positive since space charge is capacitive (Chao convention).
-    if (useSpaceCharge != 0) {
-        double mu_0 = 4.0 * OrbitConst::PI * 1.e-07; // permeability of free space
-        double _z_0 = OrbitConst::c * mu_0;
-
-        zSpaceCharge_n = _z_0 * (1.0 + 2.0 * log(b_a)) /
-                         (2 * sp->getBeta() * sp->getGamma() * sp->getGamma());
-    }
-
-    for (int n = 1; n < nBins / 2; n++) {
-        realPart = std::real(_zImped_n[n]);
-        imagPart = std::imag(_zImped_n[n]) + zSpaceCharge_n;
-        _z[n] = n * sqrt(realPart * realPart + imagPart * imagPart);
-        _chi[n] = atan2(imagPart, realPart);
-    }
-
-    // Convert charge to current for a single macroparticle per unit bin length.
-    double charge2current = bunch->getCharge() * bunch->getMacroSize() * OrbitConst::elementary_charge_MKS * sp->getBeta() * OrbitConst::c / (length / nBins);
-
-    // Calculate and add the kick to macroparticles.
-    double kick, angle, position;
-
-    // Convert particle longitudinal coordinate to phi.
-    double philocal;
-    double z;
-    double **coords = bunch->coordArr();
-    for (int j = 0; j < bunch->getSize(); j++) {
-        z = bunch->z(j);
-        philocal = (z / length) * 2 * OrbitConst::PI;
-
-        // Handle cases where the longitudinal coordinate is
-        // outside of the user-specified length
-        if (philocal < -OrbitConst::PI)
-            philocal += 2 * OrbitConst::PI;
-        if (philocal > OrbitConst::PI)
-            philocal -= 2 * OrbitConst::PI;
-
-        double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-        coords[j][5] += dE;
-    }
 }
 
 

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -184,9 +184,6 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
                 philocal -= 2 * OrbitConst::PI;
 
             double dE = _kick(philocal) * (-1e-9) * bunch->getCharge() * charge2current;
-            if (j == 0) {
-                std::cout << "debug j= " << j << " dE = " << dE << "\n"; 
-            }
             coords[j][5] += dE;
         }
     }
@@ -221,9 +218,6 @@ void LSpaceChargeCalc::trackBunch(Bunch *bunch) {
             }
 
             double energy_kick = -factor * density_gradient;
-            if (j == 0) {
-                std::cout << "debug j= " << j << " dE = " << energy_kick << "\n"; 
-            }
             coords[j][5] += energy_kick;
         }
     }

--- a/src/spacecharge/LSpaceChargeCalc.cc
+++ b/src/spacecharge/LSpaceChargeCalc.cc
@@ -99,10 +99,6 @@ void LSpaceChargeCalc::assignImpedanceValue(int n, double real, double imag)
 
 void LSpaceChargeCalc::trackBunch(Bunch* bunch)
 {
-
-  std::cout << "nbins=" << nBins << " nfreq=" << nFreq << std::endl; 
-
-    
   int nPartsGlobal = bunch->getSizeGlobal();
   if(nPartsGlobal < nMacrosMin) return;
 

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -38,7 +38,7 @@ public:
 	void setNumModes(int n);
 
 	/** Sets option to use gradient rather than impedance. **/
-	void setUseGrad(int n);
+	void setUseGrad(int setting);
 
 	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -29,17 +29,21 @@ class LSpaceChargeCalc: public OrbitUtils::CppPyWrapper
 public:
 
 	/** Constructor */
-	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in, int nFreq_in);
+	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in);
 
 	/** Destructor */
 	virtual ~LSpaceChargeCalc();
 
-	/** Calculates space charge and applies the transverse and
-	longitudinal SC kicks to the macro-particles in the bunch. */
+	/** Sets number of FFT modes used to calculate energy kick from impedance. **/
+	void setNumModes(int n);
+
+	/** Sets option to use gradient rather than impedance. **/
+	void setUseGrad(int n);
+
+	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);
 
-	/** Assigns the real and imaginary parts of the
-        machine impedance for index n**/
+	/** Assigns the real and imaginary parts of the machine impedance for index n**/
 	void assignImpedanceValue(int n, double real, double imag);
 
 	/** Routine for calculating the kick to the particle **/
@@ -52,7 +56,8 @@ public:
 	int nBins;
 	int nMacrosMin;
 	int useSpaceCharge;
-    int nFreq;
+    int nModes;
+    int useGrad;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -29,7 +29,7 @@ class LSpaceChargeCalc: public OrbitUtils::CppPyWrapper
 public:
 
 	/** Constructor */
-	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in);
+	LSpaceChargeCalc(double b_a_in, double length_in, int nMacrosMin_in, int useSpaceCharge_in, int zSize_in, int nFreq_in);
 
 	/** Destructor */
 	virtual ~LSpaceChargeCalc();
@@ -52,6 +52,7 @@ public:
 	int nBins;
 	int nMacrosMin;
 	int useSpaceCharge;
+    int nFreq;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/LSpaceChargeCalc.hh
+++ b/src/spacecharge/LSpaceChargeCalc.hh
@@ -40,6 +40,9 @@ public:
 	/** Sets option to use gradient rather than impedance. **/
 	void setUseGrad(int setting);
 
+	/** Sets option to use smooth gradient of longitudinal density. **/
+	void setSmoothGrad(int setting);
+
 	/** Calculates space charge and applies the transverse and longitudinal SC kicks to the macro-particles in the bunch. */
 	void trackBunch(Bunch* bunch);
 
@@ -58,6 +61,7 @@ public:
 	int useSpaceCharge;
     int nModes;
     int useGrad;
+    int smooth;
 
 //protected:
 	Grid1D* zGrid;

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,8 +46,10 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
+        int nModes;
+        int useGrad;
 
-		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
+		if(!PyArg_ParseTuple(args,"ddiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
 		}
 
@@ -92,37 +94,31 @@ extern "C"
 
 	}
 
-	static PyObject* LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args){
-
+    static PyObject *LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args) {
 		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
 		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
 
-		int n = -1;
-        
-		if(!PyArg_ParseTuple(args,"i:arguments", &n)){
+        int nmodes;
+        if (!PyArg_ParseTuple(args, "i:arguments", &nmodes)) {
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setNumModes(n) - constructor needs parameters.");
-		}
-		cpp_LSpaceChargeCalc->setNumModes(n);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-
-	static PyObject* LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args){
-
+        }
+		cpp_LSpaceChargeCalc->setNumModes(nmodes);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    
+    static PyObject *LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args) {
 		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
 		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
 
-		int setting = 0;
-        
-		if(!PyArg_ParseTuple(args,"i:arguments", &setting)){
+        int usegrad;
+        if (!PyArg_ParseTuple(args, "i:arguments", &usegrad)) {
 			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setUseGrad(setting) - constructor needs parameters.");
-		}
-		cpp_LSpaceChargeCalc->setUseGrad(setting);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
+        }
+		cpp_LSpaceChargeCalc->setUseGrad(usegrad);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
 
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){
@@ -180,9 +176,11 @@ extern "C"
   // defenition of the methods of the python LSpaceChargeCalc wrapper class
   // they will be vailable from python level
   static PyMethodDef LSpaceChargeCalcClassMethods[] = {
-		{ "trackBunch",  LSpaceChargeCalc_trackBunch, METH_VARARGS,"trackBunch the bunch - trackBunch(pyBunch)"},
-		{ "assignImpedanceValue",  LSpaceChargeCalc_assignImpedanceValue, METH_VARARGS,"assigne the impedance for the ith mode - assignImpedanceValue(i,real,imag)"},
-		{ "assignImpedance",  assignImpedance, METH_VARARGS,"assigne the impedance for the ith mode - assignImpedance(Z))"},
+		{ "trackBunch", LSpaceChargeCalc_trackBunch, METH_VARARGS,"trackBunch the bunch - trackBunch(pyBunch)"},
+		{ "assignImpedanceValue", LSpaceChargeCalc_assignImpedanceValue, METH_VARARGS,"assign impedance of ith mode - assignImpedanceValue(i, real, imag)"},
+		{ "assignImpedance", assignImpedance, METH_VARARGS, "assign impedance of ith mode - assignImpedance(Z))"},
+		{ "setNumModes", LSpaceChargeCalc_setNumModes, METH_VARARGS, "set number of FFT modes used to calculate energy kick"},
+		{ "setUseGrad", LSpaceChargeCalc_setUseGrad, METH_VARARGS, "set whether to use gradient-based solver"},
 		{NULL}
   };
 

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,13 +46,12 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
-        int nFreq;
 
-		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins, &nFreq)){
-			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq) - constructor needs parameters.");
+		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
 		}
 
-		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq);
+		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins);
 
 		((LSpaceChargeCalc*) self->cpp_obj)->setPyWrapper((PyObject*) self);
 
@@ -93,7 +92,37 @@ extern "C"
 
 	}
 
+	static PyObject* LSpaceChargeCalc_setNumModes(PyObject *self, PyObject *args){
 
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+		int n = -1;
+        
+		if(!PyArg_ParseTuple(args,"i:arguments", &n)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setNumModes(n) - constructor needs parameters.");
+		}
+		cpp_LSpaceChargeCalc->setNumModes(n);
+
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	static PyObject* LSpaceChargeCalc_setUseGrad(PyObject *self, PyObject *args){
+
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+		int setting = 0;
+        
+		if(!PyArg_ParseTuple(args,"i:arguments", &setting)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setUseGrad(setting) - constructor needs parameters.");
+		}
+		cpp_LSpaceChargeCalc->setUseGrad(setting);
+
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
 
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -46,12 +46,13 @@ extern "C"
 		int nMacrosMin;
 		int useSpaceCharge;
 		int nBins;
+        int nFreq;
 
-		if(!PyArg_ParseTuple(args,"ddiii:arguments",&b_a,&length,&nMacrosMin,&useSpaceCharge,&nBins)){
-			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins) - constructor needs parameters.");
+		if(!PyArg_ParseTuple(args,"ddiiii:arguments", &b_a, &length, &nMacrosMin, &useSpaceCharge, &nBins, &nFreq)){
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq) - constructor needs parameters.");
 		}
 
-		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins);
+		self->cpp_obj = new LSpaceChargeCalc(b_a, length, nMacrosMin, useSpaceCharge, nBins, nFreq);
 
 		((LSpaceChargeCalc*) self->cpp_obj)->setPyWrapper((PyObject*) self);
 

--- a/src/spacecharge/wrap_lspacechargecalc.cc
+++ b/src/spacecharge/wrap_lspacechargecalc.cc
@@ -120,6 +120,19 @@ extern "C"
         return Py_None;
     }
 
+    static PyObject *LSpaceChargeCalc_setSmoothGrad(PyObject *self, PyObject *args) {
+		pyORBIT_Object* pyLSpaceChargeCalc = (pyORBIT_Object*) self;
+		LSpaceChargeCalc* cpp_LSpaceChargeCalc = (LSpaceChargeCalc*) pyLSpaceChargeCalc->cpp_obj;
+
+        int smoothgrad;
+        if (!PyArg_ParseTuple(args, "i:arguments", &smoothgrad)) {
+			ORBIT_MPI_Finalize("PyLSpaceChargeCalc - setSmoothGrad(setting) - constructor needs parameters.");
+        }
+		cpp_LSpaceChargeCalc->setSmoothGrad(smoothgrad);
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
 	//assignImpedanceValue(int, real, real).  Wraps the LongSpaceChargeCalc routine assigning an impedance mode
 	static PyObject* LSpaceChargeCalc_assignImpedanceValue(PyObject *self, PyObject *args){
 
@@ -181,6 +194,7 @@ extern "C"
 		{ "assignImpedance", assignImpedance, METH_VARARGS, "assign impedance of ith mode - assignImpedance(Z))"},
 		{ "setNumModes", LSpaceChargeCalc_setNumModes, METH_VARARGS, "set number of FFT modes used to calculate energy kick"},
 		{ "setUseGrad", LSpaceChargeCalc_setUseGrad, METH_VARARGS, "set whether to use gradient-based solver"},
+		{ "setSmoothGrad", LSpaceChargeCalc_setSmoothGrad, METH_VARARGS, "set whether to use smooth gradients"},
 		{NULL}
   };
 


### PR DESCRIPTION
This PR adds the option to calculate the longitudinal space charge kick in `LSpaceChargeCalc` using the gradient of the charge density. The current solver calculates the kick in frequency space using the impedance formulation.

An option has also been added to set the number of FFT modes used to calculate the energy kicks in the impedance-based formulation. Before it was set to half the number of grid cells.