### PR TITLE
Use `python.dependency()` instead of `INCLUDEPY` to fix mesonpy buid in PEP517

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ base = meson.current_source_dir() + '/core'
 
 dependencies = []
 
+dependencies += python.dependency()
 dependencies += dependency('fftw3', version: '>= 3.0.0', required: true)
 
 # Detecting if MPICH or OPENMPI are installed and enabling support if present
@@ -249,35 +250,33 @@ sources = files([
 	'teapot/MatrixGenerator.cc'
 ])
 inc = include_directories([
-  python.get_variable('INCLUDEPY', ''),
     'main',
-	'orbit/SynchPartRedefinition',
-	'trackerrk4',
-	'utils/ellipticalint',
-	'teapot',
-	'mpi',
-	'orbit/ParticlesAttributes',
-	'orbit/Errors',
-	'orbit/FieldTracker',
-	'utils/statistics',
-	'utils',
-	'linac/tracking',
-	'spacecharge',
-	'orbit/MaterialInteractions',
-	'utils/field_sources',
-	'utils/bunch',
-	'orbit/Impedances',
-	'utils/harmonic_analysis',
-	'linac',
-	'utils/polynomial',
-	'linac/rfgap',
-	'orbit/RFCavities',
-	'utils/matrix',
-	'orbit/BunchDiagnostics',
-	'orbit',
-	'utils/integration',
-	'orbit/Apertures'
-
+    'orbit/SynchPartRedefinition',
+    'trackerrk4',
+    'utils/ellipticalint',
+    'teapot',
+    'mpi',
+    'orbit/ParticlesAttributes',
+    'orbit/Errors',
+    'orbit/FieldTracker',
+    'utils/statistics',
+    'utils',
+    'linac/tracking',
+    'spacecharge',
+    'orbit/MaterialInteractions',
+    'utils/field_sources',
+    'utils/bunch',
+    'orbit/Impedances',
+    'utils/harmonic_analysis',
+    'linac',
+    'utils/polynomial',
+    'linac/rfgap',
+    'orbit/RFCavities',
+    'utils/matrix',
+    'orbit/BunchDiagnostics',
+    'orbit',
+    'utils/integration',
+    'orbit/Apertures'
 ])
 
 


### PR DESCRIPTION
The PyORBIT3 build can fail while using a PEP 517-compliant build front end (e.g., `pixi`) if the temporary build environment is placed within the source tree.

```sh
pixi add --pypi 'pyorbit @ file:///path/to/PyORBIT3'
```

results in  

```
../src/meson.build:252:6: ERROR: Tried to form an absolute path to a dir in the source tree.
      You should not do that but use relative paths instead, for
      directories that are part of your project.
```

This PR makes a small modification to `meson.build` declaring Python as an explicit dependency so that the appropriate paths to Python headers/libs are resolved automatically by meson.