### PR TITLE
LinacAccNode will have XML Data Adaptor and a reference to the parent sequence

### DIFF
--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -41,9 +41,25 @@ class BaseLinacNode(AccNodeBunchTracker):
         self.setType("baseLinacNode")
         self.setParam("pos", 0.0)
         self.__linacSeqence = None
+        #-------------------------------------------------
+        # XML data adaptor of this node. 
+        #-------------------------------------------------
+        self.data_adaptor = None
         # by default we use the TEAPOT tracker module
         self.tracking_module = TPB
-
+        
+    def setDataAdaptor(self,data_adaptor):
+        """
+        Sets the XML data adaptor of this node.
+        """
+        self.data_adaptor = data_adaptor
+        
+    def getDataAdaptor(self):
+        """
+        Returns the XML data adaptor of this node.
+        """
+        return self.data_adaptor
+        
     def setLinacTracker(self, switch=True):
         """
         This method will switch tracker module to the linac specific traker by default
@@ -64,6 +80,9 @@ class BaseLinacNode(AccNodeBunchTracker):
         Sets the seqence.
         """
         self.__linacSeqence = seq
+        #---- set up Sequence for all children
+        for child_node in self.getAllChildren():
+            child_node.setSequence(seq)
 
     def setPosition(self, pos):
         """

--- a/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
+++ b/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
@@ -301,6 +301,9 @@ class SNS_LinacLatticeFactory:
                         accNode = MarkerLinacNode(node_da.stringValue("name"))
                     accNode.setParam("pos", node_pos)
                     thinNodes.append(accNode)
+                #--------------------------------------
+                #---- sets up copy of XML data adaptor of this node
+                accNode.setDataAdaptor(node_da.getDeepCopy())
             # ----- assign the thin nodes that are inside the thick nodes
             unusedThinNodes = []
             for thinNode in thinNodes:


### PR DESCRIPTION
There are two changes in the Linac nodes and lattice:
1. Each LinacAccNode will have the copy of its own Data Adapter. It will allow to keep additional information for the future parsing if the user will need it. It could be PV names. In the SNS case it is the BPM length and orientation that we need for Online Model. The user could completely ignore the presence of this data.
2. The each AccNode will know its parent sequence. Before, only the level 1 nodes had this reference. Now we set it up even for children for consistency.