### PR TITLE
Scale SC kicks with mass: update classicalRadius variable of Bunch

### DIFF
--- a/src/orbit/Bunch.cc
+++ b/src/orbit/Bunch.cc
@@ -808,6 +808,7 @@ void Bunch::updateClassicalRadius(){
     val *= OrbitConst::mass_proton/mass;
     val *= charge*charge;
     bunchAttr->doubleVal("classical_radius",val);
+    classicalRadius = val;
 }
 
 double  Bunch::setMacroSize(double val){


### PR DESCRIPTION
Update classicalRadius variable of Bunch in addition to the bunchAttr value. This fixes the scaling of SC strength with mass as the former is the value used for the SC kicks.