### PR TITLE
Pytest `Bunch` tests

### DIFF
--- a/.github/workflows/pip-build.sh
+++ b/.github/workflows/pip-build.sh
@@ -4,3 +4,4 @@ pip install -U pip
 pip install -r requirements.txt
 pip install -U setuptools
 pip install --no-build-isolation --editable .
+pip install ".[numpy]"

--- a/.github/workflows/pip-tests.sh
+++ b/.github/workflows/pip-tests.sh
@@ -1,3 +1,4 @@
 . .po3/bin/activate
+python -m pytest tests/py/ -v
 cd examples/SNS_Linac/pyorbit3_linac_model/
 python pyorbit3_sns_linac_mebt_hebt2.py

--- a/.github/workflows/pip-tests.sh
+++ b/.github/workflows/pip-tests.sh
@@ -1,4 +1,5 @@
 . .po3/bin/activate
+pip install pytest
 python -m pytest tests/py/ -v
 cd examples/SNS_Linac/pyorbit3_linac_model/
 python pyorbit3_sns_linac_mebt_hebt2.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,9 @@ authors = [
 
 [tool.setuptools_scm]
 
+[project.optional-dependencies]
+numpy = [
+    "numpy",
+]
+
 

--- a/src/orbit/wrap_bunch.cc
+++ b/src/orbit/wrap_bunch.cc
@@ -158,6 +158,19 @@ namespace wrap_orbit_bunch{
     return Py_BuildValue("i",ind);
   }
 
+  static PyObject* Bunch_recoverParticle(PyObject *self, PyObject *args){
+    Bunch *cpp_bunch = (Bunch*) ((pyORBIT_Object *) self)->cpp_obj;
+    int ind;
+
+    if(!PyArg_ParseTuple(args,"i:recoverParticle",&ind)){
+      error("PyBunch - recoverParticle - needs index of particle for recovering");
+    }
+
+    cpp_bunch->recoverParticle(ind);
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
   //removes all particles from the Bunch object
   //this is implementation of the deleteAllParticles()  method
   static PyObject* Bunch_deleteAllParticles(PyObject *self, PyObject *args){
@@ -1181,6 +1194,7 @@ namespace wrap_orbit_bunch{
     { "addParticle",                    Bunch_addParticle                   ,METH_VARARGS,"Adds a macro-particle to the bunch"},
     { "deleteParticle",                 Bunch_deleteParticle                ,METH_VARARGS,"Removes macro-particle from the bunch and call compress inside"},
     { "deleteParticleFast",             Bunch_deleteParticleFast            ,METH_VARARGS,"Removes macro-particle from the bunch very fast"},
+    { "recoverParticle",                Bunch_recoverParticle               ,METH_VARARGS,"Recovers a particle marked for removal"},
     { "deleteAllParticles",             Bunch_deleteAllParticles            ,METH_VARARGS,"Removes all macro-particles from the bunch"},
     { "compress",                       Bunch_compress                      ,METH_VARARGS,"Compress the bunch"},
     { "x",                              Bunch_x                             ,METH_VARARGS,"Set x(index,value) or get x(index) coordinate"},

--- a/tests/py/orbit/test_bunch.py
+++ b/tests/py/orbit/test_bunch.py
@@ -1,0 +1,542 @@
+import pytest
+from orbit.core.bunch import Bunch
+
+
+@pytest.fixture
+def bunch():
+    """Create a basic proton bunch."""
+    b = Bunch()
+    b.mass(0.938272)
+    b.charge(1.0)
+    b.getSyncParticle().kinEnergy(1.0)
+    return b
+
+
+class TestBunchCreation:
+
+    def test_empty_bunch_has_no_particles(self, bunch):
+        assert bunch.getSize() == 0
+        assert bunch.getTotalCount() == 0
+
+    def test_default_mass_and_charge(self, bunch):
+        assert bunch.mass() == pytest.approx(0.938272)
+        assert bunch.charge() == pytest.approx(1.0)
+
+
+class TestAddParticle:
+
+    def test_add_particle_stores_coords_correctly(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.x(idx) == 1.0
+        assert bunch.px(idx) == 0.01
+        assert bunch.y(idx) == 2.0
+        assert bunch.py(idx) == 0.02
+        assert bunch.z(idx) == 3.0
+        assert bunch.pz(idx) == 0.03
+
+    def test_add_multiple_particles_increases_size(self, bunch):
+        for i in range(5):
+            bunch.addParticle(
+                float(i) * 1e-3, float(i) * 1e-4,
+                float(i) * 1e-3, float(i) * 1e-4,
+                float(i) * 1e-3, float(i) * 1e-4,
+            )
+        assert bunch.getSize() == 5
+
+    def test_add_particle_returns_consecutive_indices(self, bunch):
+        indices = []
+        for i in range(5):
+            idx = bunch.addParticle(
+                float(i) * 1e-3, float(i) * 1e-4,
+                float(i) * 1e-3, float(i) * 1e-4,
+                float(i) * 1e-3, float(i) * 1e-4,
+            )
+            indices.append(idx)
+        assert indices == [0, 1, 2, 3, 4]
+
+    def test_many_particles_dont_interfere(self, bunch):
+        """Each particle's coordinates are independent."""
+        for i in range(10):
+            bunch.addParticle(float(i), 0.0, 0.0, 0.0, 0.0, 0.0)
+        for i in range(10):
+            assert bunch.x(i) == float(i)
+
+
+class TestCoordinateAccessors:
+
+    def test_get_x(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.x(idx) == 1.0
+
+    def test_get_px(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.px(idx) == 0.01
+
+    def test_get_y(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.y(idx) == 2.0
+
+    def test_get_py(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.py(idx) == 0.02
+
+    def test_get_z(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.z(idx) == 3.0
+
+    def test_get_pz(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.pz(idx) == 0.03
+
+    def test_set_x(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.x(idx, 99.0)
+        assert bunch.x(idx) == 99.0
+
+    def test_set_y(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.y(idx, 88.0)
+        assert bunch.y(idx) == 88.0
+
+    def test_set_z(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.z(idx, 77.0)
+        assert bunch.z(idx) == 77.0
+
+    def test_set_px(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.px(idx, 0.99)
+        assert bunch.px(idx) == 0.99
+
+    def test_set_py(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.py(idx, 0.88)
+        assert bunch.py(idx) == 0.88
+
+    def test_set_pz(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.pz(idx, 0.77)
+        assert bunch.pz(idx) == 0.77
+
+    def test_xp_is_px(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.xp(idx) == bunch.px(idx)
+
+    def test_yp_is_py(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.yp(idx) == bunch.py(idx)
+
+    def test_dE_is_pz(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        assert bunch.dE(idx) == bunch.pz(idx)
+
+    def test_set_xp(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.xp(idx, 0.99)
+        assert bunch.xp(idx) == 0.99
+        assert bunch.px(idx) == 0.99
+
+    def test_set_yp(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.yp(idx, 0.88)
+        assert bunch.yp(idx) == 0.88
+        assert bunch.py(idx) == 0.88
+
+    def test_set_dE(self, bunch):
+        idx = bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.dE(idx, 0.77)
+        assert bunch.dE(idx) == 0.77
+        assert bunch.pz(idx) == 0.77
+
+
+class TestParticleLifecycle:
+
+    def test_delete_particle(self, bunch):
+        for i in range(5):
+            bunch.addParticle(float(i) * 1e-3, 0, 0, 0, 0, 0)
+        assert bunch.getSize() == 5
+        bunch.deleteParticle(2)
+        assert bunch.getSize() == 4
+
+    def test_delete_particle_fast_no_compress(self, bunch):
+        for i in range(5):
+            bunch.addParticle(float(i) * 1e-3, 0, 0, 0, 0, 0)
+        bunch.deleteParticleFast(2)
+        assert bunch.getSize() == 5
+        assert bunch.flag(2) == 0
+
+    def test_delete_particle_fast_then_compress(self, bunch):
+        for i in range(5):
+            bunch.addParticle(float(i) * 1e-3, 0, 0, 0, 0, 0)
+        bunch.deleteParticleFast(2)
+        bunch.compress()
+        assert bunch.getSize() == 4
+
+    def test_flag_for_alive(self, bunch):
+        idx = bunch.addParticle(0, 0, 0, 0, 0, 0)
+        assert bunch.flag(idx) == 1
+
+    def test_flag_for_dead(self, bunch):
+        idx = bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.deleteParticleFast(idx)
+        assert bunch.flag(idx) == 0
+
+    def test_recover_particle(self, bunch):
+        idx = bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.deleteParticleFast(idx)
+        assert bunch.flag(idx) == 0
+        bunch.recoverParticle(idx)
+        assert bunch.flag(idx) == 1
+
+    def test_delete_all_particles(self, bunch):
+        for i in range(10):
+            bunch.addParticle(0, 0, 0, 0, 0, 0)
+        assert bunch.getSize() == 10
+        bunch.deleteAllParticles()
+        assert bunch.getSize() == 0
+        assert bunch.getTotalCount() == 0
+
+    def test_compress_no_dead_particles(self, bunch):
+        for i in range(3):
+            bunch.addParticle(float(i), 0, 0, 0, 0, 0)
+        size_before = bunch.getSize()
+        bunch.compress()
+        assert bunch.getSize() == size_before
+        for i in range(3):
+            assert bunch.x(i) == float(i)
+
+    def test_compress_multiple_times(self, bunch):
+        for i in range(5):
+            bunch.addParticle(float(i) * 1e-3, 0, 0, 0, 0, 0)
+        bunch.deleteParticleFast(2)
+        bunch.compress()
+        size1 = bunch.getSize()
+        bunch.compress()
+        assert bunch.getSize() == size1
+
+    def test_hard_delete_then_recover(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addParticle(1.0, 0, 0, 0, 0, 0)
+        assert bunch.getSize() == 2
+        bunch.deleteParticle(0)
+        assert bunch.getSize() == 1
+        assert bunch.x(0) == 1.0
+        bunch.recoverParticle(0)
+        assert bunch.flag(0) == 1
+
+    def test_flag_after_hard_delete(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.deleteParticle(0)
+        assert bunch.flag(0) == 1
+
+    def test_delete_last_particle(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.deleteParticle(0)
+        assert bunch.getSize() == 0
+
+
+class TestBunchAttributes:
+
+    def test_mass(self, bunch):
+        assert bunch.mass() == pytest.approx(0.938272)
+        bunch.mass(0.139570)
+        assert bunch.mass() == pytest.approx(0.139570)
+
+    def test_charge(self, bunch):
+        assert bunch.charge() == pytest.approx(1.0)
+        bunch.charge(-1.0)
+        assert bunch.charge() == pytest.approx(-1.0)
+
+    def test_macro_size(self, bunch):
+        bunch.macroSize(1e10)
+        assert bunch.macroSize() == 1e10
+
+    def test_classical_radius(self, bunch):
+        rp = bunch.classicalRadius()
+        assert rp == pytest.approx(1.534698e-18, rel=1e-6)
+
+    def test_b_rho_positive(self, bunch):
+        assert bunch.B_Rho() > 0
+
+    def test_bunch_attr_double_round_trip(self, bunch):
+        bunch.bunchAttrDouble("my_double", 42.0)
+        assert bunch.bunchAttrDouble("my_double") == 42.0
+
+    def test_bunch_attr_int_round_trip(self, bunch):
+        bunch.bunchAttrInt("my_int", 42)
+        assert bunch.bunchAttrInt("my_int") == 42
+
+    def test_has_bunch_attr_double(self, bunch):
+        assert bunch.hasBunchAttrDouble("mass") == 1
+        assert bunch.hasBunchAttrDouble("nonexistent") == 0
+
+    def test_bunch_attr_names(self, bunch):
+        names = bunch.bunchAttrDoubleNames()
+        assert "mass" in names
+        assert "charge" in names
+        assert "classical_radius" in names
+        assert "macro_size" in names
+
+    def test_macro_size_default(self, bunch):
+        assert bunch.macroSize() == 0.0
+
+    def test_bunch_attr_int_names(self, bunch):
+        bunch.bunchAttrInt("my_int", 42)
+        names = bunch.bunchAttrIntNames()
+        assert "my_int" in names
+
+    def test_has_bunch_attr_int(self, bunch):
+        assert bunch.hasBunchAttrInt("nonexistent") == 0
+        bunch.bunchAttrInt("my_int", 42)
+        assert bunch.hasBunchAttrInt("my_int") == 1
+
+    def test_b_rho_after_energy_change(self, bunch):
+        brho1 = bunch.B_Rho()
+        sp = bunch.getSyncParticle()
+        sp.kinEnergy(2.0)
+        assert bunch.B_Rho() != pytest.approx(brho1, rel=1e-6)
+
+    def test_classical_radius_after_mass_change(self, bunch):
+        rc1 = bunch.classicalRadius()
+        bunch.mass(0.139570)
+        rc2 = bunch.classicalRadius()
+        assert rc2 != rc1
+
+
+class TestParticleAttributes:
+
+    def test_add_part_attr(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("ParticleIdNumber")
+        assert bunch.hasPartAttr("ParticleIdNumber") == 1
+
+    def test_part_attr_value_round_trip(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("ParticleIdNumber")
+        bunch.partAttrValue("ParticleIdNumber", 0, 0, 42)
+        assert bunch.partAttrValue("ParticleIdNumber", 0, 0) == 42
+
+    def test_remove_part_attr(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("ParticleIdNumber")
+        assert bunch.hasPartAttr("ParticleIdNumber") == 1
+        bunch.removePartAttr("ParticleIdNumber")
+        assert bunch.hasPartAttr("ParticleIdNumber") == 0
+
+    def test_get_part_attr_names(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("ParticleIdNumber")
+        names = bunch.getPartAttrNames()
+        assert "ParticleIdNumber" in names
+
+    def test_remove_all_part_attr(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("TurnNumber")
+        bunch.addPartAttr("ParticleIdNumber")
+        assert len(bunch.getPartAttrNames()) == 2
+        bunch.removeAllPartAttr()
+        assert bunch.getPartAttrNames() == ()
+
+    def test_get_part_attr_dicts(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("TurnNumber")
+        dicts = bunch.getPartAttrDicts()
+        assert "TurnNumber" in dicts
+        assert "size" in dicts["TurnNumber"]
+
+    def test_get_possible_part_attr_names(self, bunch):
+        names = bunch.getPossiblePartAttrNames()
+        assert "TurnNumber" in names
+        assert "ParticleIdNumber" in names
+
+    def test_get_part_attr_size(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.addPartAttr("TurnNumber")
+        assert bunch.getPartAttrSize("TurnNumber") == 1
+
+    def test_multiple_particles_with_attributes(self, bunch):
+        bunch.addPartAttr("ParticleIdNumber")
+        for i in range(5):
+            bunch.addParticle(float(i) * 1e-3, 0, 0, 0, 0, 0)
+            bunch.partAttrValue("ParticleIdNumber", i, 0, 100 + i)
+        for i in range(5):
+            assert bunch.partAttrValue(
+                "ParticleIdNumber", i, 0
+            ) == pytest.approx(100.0 + i)
+
+
+class TestCopyOperations:
+
+    def test_copy_empty_bunch_to(self, bunch):
+        src = bunch
+        src.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        dst = Bunch()
+        src.copyEmptyBunchTo(dst)
+        assert dst.getSize() == 0
+        assert dst.mass() == pytest.approx(src.mass())
+        assert dst.charge() == pytest.approx(src.charge())
+
+    def test_copy_bunch_to(self, bunch):
+        src = bunch
+        src.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        dst = Bunch()
+        src.copyBunchTo(dst)
+        assert dst.getSize() == 1
+        assert dst.x(0) == 1.0
+        assert dst.y(0) == 2.0
+        assert dst.z(0) == 3.0
+
+    def test_add_particles_to(self, bunch):
+        src = bunch
+        src.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        dst = Bunch()
+        dst.mass(0.938272)
+        dst.charge(1.0)
+        src.addParticlesTo(dst)
+        assert dst.getSize() == 1
+        assert dst.x(0) == 1.0
+        assert dst.py(0) == 0.02
+
+
+class TestRingWrap:
+
+    def test_ringwrap_inside_stays(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 1.0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(1.0)
+
+    def test_ringwrap_wraps(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 15.0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(-5.0)
+
+    def test_ringwrap_negative(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, -15.0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(5.0)
+
+    def test_ringwrap_at_zero(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(0.0)
+
+    def test_ringwrap_beyond_full_ring(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 25.0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(-5.0)
+        bunch.addParticle(0, 0, 0, 0, -25.0, 0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(1) == pytest.approx(5.0)
+
+    def test_ringwrap_idempotent(self, bunch):
+        bunch.addParticle(0, 0, 0, 0, 15.0, 0)
+        bunch.ringwrap(20.0)
+        z_first = bunch.z(0)
+        bunch.ringwrap(20.0)
+        assert bunch.z(0) == pytest.approx(z_first)
+
+
+class TestBunchCapacity:
+
+    def test_get_capacity(self, bunch):
+        assert bunch.getCapacity() > 0
+
+    def test_get_size_global(self, bunch):
+        assert bunch.getSizeGlobal() == 0
+
+    def test_get_size_global_from_memory(self, bunch):
+        assert bunch.getSizeGlobalFromMemory() == 0
+
+    def test_get_total_count_tracks_allocation(self, bunch):
+        for i in range(5):
+            bunch.addParticle(0, 0, 0, 0, 0, 0)
+        assert bunch.getTotalCount() == 5
+        bunch.deleteParticleFast(2)
+        bunch.addParticle(99, 0, 0, 0, 0, 0)
+        assert bunch.getTotalCount() == 6
+
+
+class TestSyncParticle:
+
+    def test_get_sync_particle(self, bunch):
+        sp = bunch.getSyncParticle()
+        assert sp.mass() == pytest.approx(0.938272)
+
+    def test_sync_particle_kin_energy(self, bunch):
+        sp = bunch.getSyncParticle()
+        sp.kinEnergy(2.0)
+        assert sp.kinEnergy() == pytest.approx(2.0)
+
+    def test_sync_particle_beta_gamma(self, bunch):
+        sp = bunch.getSyncParticle()
+        beta = sp.beta()
+        gamma = sp.gamma()
+        assert gamma == pytest.approx(1.0 / (1.0 - beta**2) ** 0.5, rel=1e-6)
+        assert beta > 0
+        assert gamma > 1.0
+
+
+class TestFileIO:
+
+    def test_dump_and_read_bunch_empty(self, bunch, tmp_path):
+        fname = str(tmp_path / "empty.bunch")
+        bunch.dumpBunch(fname)
+        b2 = Bunch()
+        b2.mass(0.938272)
+        b2.charge(1.0)
+        b2.getSyncParticle().kinEnergy(1.0)
+        b2.readBunch(fname)
+        assert b2.getSize() == 0
+        assert b2.mass() == pytest.approx(0.938272)
+        assert b2.charge() == pytest.approx(1.0)
+
+    def test_dump_and_read_bunch_single(self, bunch, tmp_path):
+        fname = str(tmp_path / "single.bunch")
+        bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.dumpBunch(fname)
+        b2 = Bunch()
+        b2.mass(0.938272)
+        b2.charge(1.0)
+        b2.getSyncParticle().kinEnergy(1.0)
+        b2.readBunch(fname)
+        assert b2.getSize() == 1
+        assert b2.x(0) == 1.0
+        assert b2.px(0) == 0.01
+        assert b2.y(0) == 2.0
+        assert b2.py(0) == 0.02
+        assert b2.z(0) == 3.0
+        assert b2.pz(0) == 0.03
+
+    def test_dump_and_read_bunch_multi(self, bunch, tmp_path):
+        fname = str(tmp_path / "multi.bunch")
+        for i in range(3):
+            bunch.addParticle(float(i), float(i) * 0.01, float(i) * 2, float(i) * 0.02, float(i) * 3, float(i) * 0.03)
+        bunch.dumpBunch(fname)
+        b2 = Bunch()
+        b2.mass(0.938272)
+        b2.charge(1.0)
+        b2.getSyncParticle().kinEnergy(1.0)
+        b2.readBunch(fname)
+        assert b2.getSize() == 3
+        for i in range(3):
+            assert b2.x(i) == float(i)
+            assert b2.px(i) == float(i) * 0.01
+            assert b2.y(i) == float(i) * 2
+            assert b2.pz(i) == float(i) * 0.03
+
+    def test_dump_and_read_with_particle_attrs(self, bunch, tmp_path):
+        fname = str(tmp_path / "attrs.bunch")
+        bunch.addParticle(1.0, 0.01, 2.0, 0.02, 3.0, 0.03)
+        bunch.addPartAttr("TurnNumber")
+        bunch.partAttrValue("TurnNumber", 0, 0, 42)
+        bunch.dumpBunch(fname)
+        b2 = Bunch()
+        b2.mass(0.938272)
+        b2.charge(1.0)
+        b2.getSyncParticle().kinEnergy(1.0)
+        b2.readBunch(fname)
+        assert b2.getSize() == 1
+        assert b2.x(0) == 1.0
+        assert b2.hasPartAttr("TurnNumber") == 1
+        assert b2.partAttrValue("TurnNumber", 0, 0) == 42


### PR DESCRIPTION
I tried letting a model (`OpenCode/big-pickle`) generate unit tests for the `Bunch` class in preparation for introducing numpy interoperability, for which it generated 79 new tests probing every method. As a result, it revealed that we were missing a wrapper for `Bunch::recoverParticle`, so I added that.

I also added numpy as an *optional* dependency in the `pyproject.toml` as well as modified workflows to run the new tests with `pytest`.

Here are the test results:

```
$ pytest -v tests/py/orbit/test_bunch.py
...
collected 79 items

tests/py/orbit/test_bunch.py::TestBunchCreation::test_empty_bunch_has_no_particles PASSED                                                                              [  1%]
tests/py/orbit/test_bunch.py::TestBunchCreation::test_default_mass_and_charge PASSED                                                                                   [  2%]
tests/py/orbit/test_bunch.py::TestAddParticle::test_add_particle_stores_coords_correctly PASSED                                                                        [  3%]
tests/py/orbit/test_bunch.py::TestAddParticle::test_add_multiple_particles_increases_size PASSED                                                                       [  5%]
tests/py/orbit/test_bunch.py::TestAddParticle::test_add_particle_returns_consecutive_indices PASSED                                                                    [  6%]
tests/py/orbit/test_bunch.py::TestAddParticle::test_many_particles_dont_interfere PASSED                                                                               [  7%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_x PASSED                                                                                               [  8%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_px PASSED                                                                                              [ 10%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_y PASSED                                                                                               [ 11%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_py PASSED                                                                                              [ 12%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_z PASSED                                                                                               [ 13%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_get_pz PASSED                                                                                              [ 15%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_x PASSED                                                                                               [ 16%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_y PASSED                                                                                               [ 17%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_z PASSED                                                                                               [ 18%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_px PASSED                                                                                              [ 20%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_py PASSED                                                                                              [ 21%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_pz PASSED                                                                                              [ 22%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_xp_is_px PASSED                                                                                            [ 24%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_yp_is_py PASSED                                                                                            [ 25%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_dE_is_pz PASSED                                                                                            [ 26%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_xp PASSED                                                                                              [ 27%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_yp PASSED                                                                                              [ 29%]
tests/py/orbit/test_bunch.py::TestCoordinateAccessors::test_set_dE PASSED                                                                                              [ 30%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_delete_particle PASSED                                                                                       [ 31%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_delete_particle_fast_no_compress PASSED                                                                      [ 32%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_delete_particle_fast_then_compress PASSED                                                                    [ 34%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_flag_for_alive PASSED                                                                                        [ 35%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_flag_for_dead PASSED                                                                                         [ 36%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_recover_particle PASSED                                                                                      [ 37%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_delete_all_particles PASSED                                                                                  [ 39%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_compress_no_dead_particles PASSED                                                                            [ 40%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_compress_multiple_times PASSED                                                                               [ 41%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_hard_delete_then_recover PASSED                                                                              [ 43%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_flag_after_hard_delete PASSED                                                                                [ 44%]
tests/py/orbit/test_bunch.py::TestParticleLifecycle::test_delete_last_particle PASSED                                                                                  [ 45%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_mass PASSED                                                                                                    [ 46%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_charge PASSED                                                                                                  [ 48%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_macro_size PASSED                                                                                              [ 49%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_classical_radius PASSED                                                                                        [ 50%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_b_rho_positive PASSED                                                                                          [ 51%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_bunch_attr_double_round_trip PASSED                                                                            [ 53%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_bunch_attr_int_round_trip PASSED                                                                               [ 54%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_has_bunch_attr_double PASSED                                                                                   [ 55%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_bunch_attr_names PASSED                                                                                        [ 56%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_macro_size_default PASSED                                                                                      [ 58%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_bunch_attr_int_names PASSED                                                                                    [ 59%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_has_bunch_attr_int PASSED                                                                                      [ 60%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_b_rho_after_energy_change PASSED                                                                               [ 62%]
tests/py/orbit/test_bunch.py::TestBunchAttributes::test_classical_radius_after_mass_change PASSED                                                                      [ 63%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_add_part_attr PASSED                                                                                        [ 64%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_part_attr_value_round_trip PASSED                                                                           [ 65%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_remove_part_attr PASSED                                                                                     [ 67%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_get_part_attr_names PASSED                                                                                  [ 68%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_remove_all_part_attr PASSED                                                                                 [ 69%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_get_part_attr_dicts PASSED                                                                                  [ 70%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_get_possible_part_attr_names PASSED                                                                         [ 72%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_get_part_attr_size PASSED                                                                                   [ 73%]
tests/py/orbit/test_bunch.py::TestParticleAttributes::test_multiple_particles_with_attributes PASSED                                                                   [ 74%]
tests/py/orbit/test_bunch.py::TestCopyOperations::test_copy_empty_bunch_to PASSED                                                                                      [ 75%]
tests/py/orbit/test_bunch.py::TestCopyOperations::test_copy_bunch_to PASSED                                                                                            [ 77%]
tests/py/orbit/test_bunch.py::TestCopyOperations::test_add_particles_to PASSED                                                                                         [ 78%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_inside_stays PASSED                                                                                          [ 79%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_wraps PASSED                                                                                                 [ 81%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_negative PASSED                                                                                              [ 82%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_at_zero PASSED                                                                                               [ 83%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_beyond_full_ring PASSED                                                                                      [ 84%]
tests/py/orbit/test_bunch.py::TestRingWrap::test_ringwrap_idempotent PASSED                                                                                            [ 86%]
tests/py/orbit/test_bunch.py::TestBunchCapacity::test_get_capacity PASSED                                                                                              [ 87%]
tests/py/orbit/test_bunch.py::TestBunchCapacity::test_get_size_global PASSED                                                                                           [ 88%]
tests/py/orbit/test_bunch.py::TestBunchCapacity::test_get_size_global_from_memory PASSED                                                                               [ 89%]
tests/py/orbit/test_bunch.py::TestBunchCapacity::test_get_total_count_tracks_allocation PASSED                                                                         [ 91%]
tests/py/orbit/test_bunch.py::TestSyncParticle::test_get_sync_particle PASSED                                                                                          [ 92%]
tests/py/orbit/test_bunch.py::TestSyncParticle::test_sync_particle_kin_energy PASSED                                                                                   [ 93%]
tests/py/orbit/test_bunch.py::TestSyncParticle::test_sync_particle_beta_gamma PASSED                                                                                   [ 94%]
tests/py/orbit/test_bunch.py::TestFileIO::test_dump_and_read_bunch_empty PASSED                                                                                        [ 96%]
tests/py/orbit/test_bunch.py::TestFileIO::test_dump_and_read_bunch_single PASSED                                                                                       [ 97%]
tests/py/orbit/test_bunch.py::TestFileIO::test_dump_and_read_bunch_multi PASSED                                                                                        [ 98%]
tests/py/orbit/test_bunch.py::TestFileIO::test_dump_and_read_with_particle_attrs PASSED                                                                                [100%]

============================================================================= 79 passed in 0.05s =============================================================================
```