### PR TITLE
The error entrance node was added as a 1st of the child nodes list of the parent node

### DIFF
--- a/py/orbit/errors/ErrorLatticeModifications.py
+++ b/py/orbit/errors/ErrorLatticeModifications.py
@@ -100,7 +100,7 @@ def addErrorNodeAsChild(lattice, AccNode, Error_Node):
 
 
 def addErrorNodeAsChild_I(lattice, AccNode, Error_Node):
-    AccNode.addChildNode(Error_Node, AccNode.ENTRANCE)
+    AccNode.getChildNodes(AccNode.ENTRANCE).insert(0, Error_Node)
     lattice.initialize()
 
 


### PR DESCRIPTION
The error entrance node was added as a 1st of the child nodes list of the parent node. Before, the tilt nodes were not rotated or shifted at the entrance when error nodes added to the parent node. That is for the TEAPOT lattice.