### PR TITLE
Update LinacAccNodes.py to fix linac lattice reverseOrder

### DIFF
--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -80,9 +80,6 @@ class BaseLinacNode(AccNodeBunchTracker):
         Sets the seqence.
         """
         self.__linacSeqence = seq
-        #---- set up Sequence for all children
-        for child_node in self.getAllChildren():
-            child_node.setSequence(seq)
 
     def setPosition(self, pos):
         """


### PR DESCRIPTION
Removed following lines from setSequence method: 
#---- set up Sequence for all children
for child_node in self.getAllChildren():
            child_node.setSequence(seq)

This was causing an issue when reverseOrder was called for a lattice that includes SC nodes - SC nodes do not inherit from LinacAccNodes so do not have setSequence method. This loop was included for consistency and removing it should not affect anything.

Closes #138 